### PR TITLE
Add config loader and guard missing config

### DIFF
--- a/src/alert_bot.py
+++ b/src/alert_bot.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from telegram import Update
 from telegram.ext import ApplicationBuilder, ContextTypes, CommandHandler
 
-from config import TG_TOKEN
+from config_utils import load_config
+
+cfg = load_config()
+TG_TOKEN = cfg.TG_TOKEN
 from log_utils import get_logger, install_excepthook
 
 log = get_logger().bind(script=__file__)

--- a/src/caption.py
+++ b/src/caption.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import openai
 
-from config import OPENAI_KEY
+from config_utils import load_config
+
+cfg = load_config()
+OPENAI_KEY = cfg.OPENAI_KEY
 from log_utils import get_logger, install_excepthook
 from notes_utils import write_md
 

--- a/src/chop.py
+++ b/src/chop.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import openai
 
-from config import OPENAI_KEY, LANGS
+from config_utils import load_config
+
+cfg = load_config()
+OPENAI_KEY = cfg.OPENAI_KEY
+LANGS = cfg.LANGS
 from log_utils import get_logger, install_excepthook
 from notes_utils import read_md
 from token_utils import estimate_tokens

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1,0 +1,19 @@
+"""Utility to load the user configuration."""
+
+from importlib import import_module
+
+from log_utils import get_logger
+
+log = get_logger().bind(module=__name__)
+
+
+def load_config():
+    """Return the ``config`` module or exit with a helpful message."""
+    try:
+        return import_module("config")
+    except ModuleNotFoundError as exc:
+        log.error(
+            "Missing config.py, copy config.example.py and fill in credentials"
+        )
+        raise SystemExit("Configuration file 'config.py' not found") from exc
+

--- a/src/embed.py
+++ b/src/embed.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import openai
 import psycopg
 
-from config import OPENAI_KEY, DB_DSN
+from config_utils import load_config
+
+cfg = load_config()
+OPENAI_KEY = cfg.OPENAI_KEY
+DB_DSN = cfg.DB_DSN
 from log_utils import get_logger, install_excepthook
 from token_utils import estimate_tokens
 

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 from telethon import TelegramClient, events
 
-from config import TG_API_ID, TG_API_HASH, TG_SESSION, CHATS
+from config_utils import load_config
+
+cfg = load_config()
+TG_API_ID = cfg.TG_API_ID
+TG_API_HASH = cfg.TG_API_HASH
+TG_SESSION = cfg.TG_SESSION
+CHATS = cfg.CHATS
 from log_utils import get_logger, install_excepthook
 from notes_utils import write_md
 


### PR DESCRIPTION
## Summary
- add `config_utils.load_config` helper
- use config loader in all scripts so missing `config.py` gives a clear error message

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68549c253a408324ad57b745f1dff312