### PR TITLE
Fix config loader

### DIFF
--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1,6 +1,8 @@
 """Utility to load the user configuration."""
 
 from importlib import import_module
+from pathlib import Path
+import sys
 
 from log_utils import get_logger
 
@@ -8,12 +10,26 @@ log = get_logger().bind(module=__name__)
 
 
 def load_config():
-    """Return the ``config`` module or exit with a helpful message."""
+    """Return the ``config`` module or exit with a helpful message.
+
+    When running the scripts directly from ``src/`` the repository root isn't on
+    ``sys.path`` and ``config.py`` can't be imported.  Try adding the parent
+    directory before failing so the configuration can live alongside
+    ``config.example.py`` in the project root.
+    """
+
     try:
         return import_module("config")
-    except ModuleNotFoundError as exc:
-        log.error(
-            "Missing config.py, copy config.example.py and fill in credentials"
-        )
-        raise SystemExit("Configuration file 'config.py' not found") from exc
+    except ModuleNotFoundError:
+        repo_root = Path(__file__).resolve().parent.parent
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+            log.debug("Added repo root to sys.path", path=str(repo_root))
+        try:
+            return import_module("config")
+        except ModuleNotFoundError as exc:
+            log.error(
+                "Missing config.py, copy config.example.py and fill in credentials"
+            )
+            raise SystemExit("Configuration file 'config.py' not found") from exc
 


### PR DESCRIPTION
## Summary
- ensure config loads from repo root when running scripts from `src/`

## Testing
- `make precommit`
- `make pull` *(fails: ModuleNotFoundError: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_68549f7817088324afc932b521496fcd