### PR TITLE
Improve Telegram sync

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -5,10 +5,11 @@ This repository powers a small Telegram marketplace.  Each Python script in
 [`setup.md`](setup.md) for installation instructions.
 
 ## tg_client.py
-Uses Telethon to mirror the target chats as a normal user account.  Incoming
-messages are stored as Markdown under `data/raw` while any media files are saved
-to `data/media` using their SHA‑256 hashes.  Nothing is deleted; edits simply
-overwrite the Markdown.
+Uses Telethon to mirror the target chats as a normal user account.  On start it
+fetches all messages newer than the last saved ID for each chat before
+listening for real‑time updates.  Incoming messages are stored as Markdown under
+`data/raw` while any media files are saved to `data/media` using their SHA‑256
+hashes.  Nothing is deleted; edits simply overwrite the Markdown.
 
 ## caption.py
 Calls GPT‑4o Vision to caption the images in `data/media`.  The result is stored

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -23,6 +23,20 @@ RAW_DIR = Path("data/raw")
 MEDIA_DIR = Path("data/media")
 
 
+def get_last_id(chat: str) -> int:
+    """Return the highest saved message id for ``chat``."""
+    chat_dir = RAW_DIR / chat
+    if not chat_dir.exists():
+        return 0
+    ids = []
+    for p in chat_dir.glob("*.md"):
+        try:
+            ids.append(int(p.stem))
+        except ValueError:
+            log.debug("Ignoring file", file=str(p))
+    return max(ids) if ids else 0
+
+
 def _save_text(chat: str, message_id: int, text: str) -> None:
     path = RAW_DIR / chat / f"{message_id}.md"
     write_md(path, text)
@@ -39,9 +53,28 @@ def _save_media(data: bytes) -> str:
     return sha
 
 
+async def fetch_missing(client: TelegramClient) -> None:
+    """Pull any messages newer than the last saved one."""
+    for chat in CHATS:
+        last_id = get_last_id(chat)
+        count = 0
+        async for msg in client.iter_messages(chat, min_id=last_id, reverse=True):
+            text = msg.message or ""
+            _save_text(chat, msg.id, text)
+            if msg.media:
+                data = await msg.download_media(bytes)
+                _save_media(data)
+            count += 1
+        log.info("Synced chat", chat=chat, new_messages=count)
+
+
 async def main() -> None:
     client = TelegramClient(TG_SESSION, TG_API_ID, TG_API_HASH)
     await client.start()
+    log.info("Logged in")
+
+    await fetch_missing(client)
+    log.info("Initial sync complete; listening for updates")
 
     @client.on(events.NewMessage(chats=CHATS))
     async def handler(event):
@@ -51,6 +84,16 @@ async def main() -> None:
         if event.message.media:
             data = await event.message.download_media(bytes)
             _save_media(data)
+
+    @client.on(events.MessageEdited(chats=CHATS))
+    async def edit_handler(event):
+        chat = event.chat.username or str(event.chat_id)
+        text = event.message.message or ""
+        _save_text(chat, event.message.id, text)
+        if event.message.media:
+            data = await event.message.download_media(bytes)
+            _save_media(data)
+        log.debug("Saved edit", chat=chat, id=event.message.id)
 
     log.info("Client started")
     await client.run_until_disconnected()

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+import types
+import importlib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_get_last_id(tmp_path, monkeypatch):
+    cfg = types.ModuleType("config")
+    cfg.TG_API_ID = 0
+    cfg.TG_API_HASH = ""
+    cfg.TG_SESSION = ""
+    cfg.CHATS = []
+    monkeypatch.setitem(sys.modules, "config", cfg)
+    tg_client = importlib.import_module("tg_client")
+
+    monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path)
+    chat = "chat1"
+    chat_dir = tmp_path / chat
+    chat_dir.mkdir()
+    (chat_dir / "1.md").write_text("msg1")
+    (chat_dir / "3.md").write_text("msg3")
+    assert tg_client.get_last_id(chat) == 3


### PR DESCRIPTION
## Summary
- sync missing Telegram messages before listening
- log initial sync and edits for better debugging
- document tg_client sync logic
- test get_last_id helper

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a1b3981c8324b363309fd1917b9d