### PR TITLE
Improve Telegram data storage

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -8,8 +8,10 @@ This repository powers a small Telegram marketplace.  Each Python script in
 Uses Telethon to mirror the target chats as a normal user account.  On start it
 fetches all messages newer than the last saved ID for each chat before
 listening for real‑time updates.  Incoming messages are stored as Markdown under
-`data/raw` while any media files are saved to `data/media` using their SHA‑256
-hashes.  Nothing is deleted; edits simply overwrite the Markdown.
+`data/raw/<chat>/<year>/<month>/<id>.md` with basic metadata at the top.  Media
+files are placed next to a `.md` description under
+`data/media/<chat>/<year>/<month>/` using their SHA‑256 hash plus extension.
+Nothing is deleted; edits simply overwrite the Markdown.
 
 ## caption.py
 Calls GPT‑4o Vision to caption the images in `data/media`.  The result is stored

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -5,6 +5,7 @@ import hashlib
 from pathlib import Path
 
 from telethon import TelegramClient, events
+from telethon.tl.custom import Message
 
 from config_utils import load_config
 
@@ -19,6 +20,9 @@ from notes_utils import write_md
 log = get_logger().bind(script=__file__)
 install_excepthook(log)
 
+# Messages are stored as Markdown with metadata under
+# data/raw/<chat>/<YYYY>/<MM>/<id>.md.  Media files live under
+# data/media/<chat>/<YYYY>/<MM>/ using their SHA-256 hash plus extension.
 RAW_DIR = Path("data/raw")
 MEDIA_DIR = Path("data/media")
 
@@ -29,7 +33,7 @@ def get_last_id(chat: str) -> int:
     if not chat_dir.exists():
         return 0
     ids = []
-    for p in chat_dir.glob("*.md"):
+    for p in chat_dir.rglob("*.md"):
         try:
             ids.append(int(p.stem))
         except ValueError:
@@ -37,20 +41,65 @@ def get_last_id(chat: str) -> int:
     return max(ids) if ids else 0
 
 
-def _save_text(chat: str, message_id: int, text: str) -> None:
-    path = RAW_DIR / chat / f"{message_id}.md"
-    write_md(path, text)
+async def _save_message(client: TelegramClient, chat: str, msg: Message) -> None:
+    """Write ``msg`` to disk with metadata and any media references."""
+    subdir = RAW_DIR / chat / f"{msg.date:%Y}" / f"{msg.date:%m}"
+    subdir.mkdir(parents=True, exist_ok=True)
+    files = []
+    if msg.media:
+        data = await msg.download_media(bytes)
+        files.append(await _save_media(chat, msg, data))
+
+    permissions = None
+    try:
+        permissions = await client.get_permissions(chat, msg.sender_id)
+    except Exception:
+        log.debug("Failed to fetch permissions", chat=chat, user=msg.sender_id)
+
+    meta = {
+        "id": msg.id,
+        "chat": chat,
+        "sender": msg.sender_id,
+        "date": msg.date.isoformat(),
+        "reply_to": msg.reply_to_msg_id,
+        "is_admin": getattr(permissions, "is_admin", False),
+    }
+    if files:
+        meta["files"] = files
+
+    # Metadata is stored as simple "key: value" pairs followed by the original
+    # message text so other scripts can easily parse it.
+    meta_lines = [f"{k}: {v}" for k, v in meta.items() if v is not None]
+    path = subdir / f"{msg.id}.md"
+    text = msg.message or ""
+    write_md(path, "\n".join(meta_lines) + "\n\n" + text)
     log.debug("Wrote message", path=str(path))
 
 
-def _save_media(data: bytes) -> str:
+async def _save_media(chat: str, msg: Message, data: bytes) -> str:
+    """Store ``data`` and return relative file path."""
+    # Files are grouped by chat and month so we don't end up with one huge
+    # directory.  A companion ``.md`` file holds basic metadata about the
+    # original file and source message.
     sha = hashlib.sha256(data).hexdigest()
-    path = MEDIA_DIR / sha
+    ext = getattr(msg.file, "ext", "") or ""
+    subdir = MEDIA_DIR / chat / f"{msg.date:%Y}" / f"{msg.date:%m}"
+    subdir.mkdir(parents=True, exist_ok=True)
+    filename = f"{sha}{ext}"
+    path = subdir / filename
     if not path.exists():
-        MEDIA_DIR.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
         log.debug("Stored media", sha=sha)
-    return sha
+    md = subdir / f"{filename}.md"
+    meta = {
+        "message_id": msg.id,
+        "date": msg.date.isoformat(),
+        "original": getattr(msg.file, "name", None),
+    }
+    meta_lines = [f"{k}: {v}" for k, v in meta.items() if v]
+    write_md(md, "\n".join(meta_lines))
+    rel = Path(chat) / f"{msg.date:%Y}" / f"{msg.date:%m}" / filename
+    return str(rel)
 
 
 async def fetch_missing(client: TelegramClient) -> None:
@@ -59,11 +108,7 @@ async def fetch_missing(client: TelegramClient) -> None:
         last_id = get_last_id(chat)
         count = 0
         async for msg in client.iter_messages(chat, min_id=last_id, reverse=True):
-            text = msg.message or ""
-            _save_text(chat, msg.id, text)
-            if msg.media:
-                data = await msg.download_media(bytes)
-                _save_media(data)
+            await _save_message(client, chat, msg)
             count += 1
         log.info("Synced chat", chat=chat, new_messages=count)
 
@@ -79,20 +124,12 @@ async def main() -> None:
     @client.on(events.NewMessage(chats=CHATS))
     async def handler(event):
         chat = event.chat.username or str(event.chat_id)
-        text = event.message.message or ""
-        _save_text(chat, event.message.id, text)
-        if event.message.media:
-            data = await event.message.download_media(bytes)
-            _save_media(data)
+        await _save_message(client, chat, event.message)
 
     @client.on(events.MessageEdited(chats=CHATS))
     async def edit_handler(event):
         chat = event.chat.username or str(event.chat_id)
-        text = event.message.message or ""
-        _save_text(chat, event.message.id, text)
-        if event.message.media:
-            data = await event.message.download_media(bytes)
-            _save_media(data)
+        await _save_message(client, chat, event.message)
         log.debug("Saved edit", chat=chat, id=event.message.id)
 
     log.info("Client started")

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -17,8 +17,8 @@ def test_get_last_id(tmp_path, monkeypatch):
 
     monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path)
     chat = "chat1"
-    chat_dir = tmp_path / chat
-    chat_dir.mkdir()
+    chat_dir = tmp_path / chat / "2024" / "05"
+    chat_dir.mkdir(parents=True)
     (chat_dir / "1.md").write_text("msg1")
     (chat_dir / "3.md").write_text("msg3")
     assert tg_client.get_last_id(chat) == 3


### PR DESCRIPTION
## Summary
- enrich tg_client message dumps with metadata and calendar folders
- record media with per-chat paths and matching metadata files
- document new layout in services overview
- adjust tests for updated path scheme

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a58fbe188324b46ea7ed124d71e9