### PR TITLE
Improve Telegram message storage

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -11,7 +11,16 @@ listening for real‑time updates.  Incoming messages are stored as Markdown und
 `data/raw/<chat>/<year>/<month>/<id>.md` with basic metadata at the top.  Media
 files are placed next to a `.md` description under
 `data/media/<chat>/<year>/<month>/` using their SHA‑256 hash plus extension.
-Nothing is deleted; edits simply overwrite the Markdown.
+Nothing is deleted; edits simply overwrite the Markdown.  Messages sent as
+albums are merged into a single file so that all attachments appear together.
+
+Metadata fields include at least:
+
+- `id`, `chat`, `date`, `reply_to`, `is_admin`
+- `sender` (numeric), `sender_name`, `sender_username`, `sender_phone`,
+  `tg_link`
+- `group_id` if part of an album
+- `files` – list of stored media paths
 
 ## caption.py
 Calls GPT‑4o Vision to caption the images in `data/media`.  The result is stored

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import hashlib
+import ast
 from pathlib import Path
 
 from telethon import TelegramClient, events
@@ -25,6 +26,31 @@ install_excepthook(log)
 # data/media/<chat>/<YYYY>/<MM>/ using their SHA-256 hash plus extension.
 RAW_DIR = Path("data/raw")
 MEDIA_DIR = Path("data/media")
+
+
+def _parse_md(path: Path) -> tuple[dict, str]:
+    """Return metadata dict and message text from ``path``."""
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    lines = text.splitlines()
+    meta = {}
+    body_start = 0
+    for i, line in enumerate(lines):
+        if not line.strip():
+            body_start = i + 1
+            break
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip()
+    body = "\n".join(lines[body_start:])
+    return meta, body
+
+
+def _write_md(path: Path, meta: dict, body: str) -> None:
+    meta_lines = [f"{k}: {v}" for k, v in meta.items() if v is not None]
+    write_md(path, "\n".join(meta_lines) + "\n\n" + body.strip())
+
+
+_GROUPS: dict[int, Path] = {}
 
 
 def get_last_id(chat: str) -> int:
@@ -56,23 +82,42 @@ async def _save_message(client: TelegramClient, chat: str, msg: Message) -> None
     except Exception:
         log.debug("Failed to fetch permissions", chat=chat, user=msg.sender_id)
 
+    sender = await msg.get_sender()
     meta = {
         "id": msg.id,
         "chat": chat,
         "sender": msg.sender_id,
+        "sender_name": " ".join(
+            p for p in [getattr(sender, "first_name", None), getattr(sender, "last_name", None)] if p
+        ) or None,
+        "sender_username": getattr(sender, "username", None),
+        "sender_phone": getattr(sender, "phone", None),
+        "tg_link": f"https://t.me/{sender.username}" if getattr(sender, "username", None) else None,
         "date": msg.date.isoformat(),
         "reply_to": msg.reply_to_msg_id,
+        "group_id": msg.grouped_id,
         "is_admin": getattr(permissions, "is_admin", False),
     }
     if files:
         meta["files"] = files
 
-    # Metadata is stored as simple "key: value" pairs followed by the original
-    # message text so other scripts can easily parse it.
-    meta_lines = [f"{k}: {v}" for k, v in meta.items() if v is not None]
-    path = subdir / f"{msg.id}.md"
-    text = msg.message or ""
-    write_md(path, "\n".join(meta_lines) + "\n\n" + text)
+    text = (msg.message or "").replace("View original post", "").strip()
+    group_path = None
+    if msg.grouped_id:
+        group_path = _GROUPS.get(msg.grouped_id)
+        if not group_path:
+            group_path = subdir / f"{msg.id}.md"
+            _GROUPS[msg.grouped_id] = group_path
+        else:
+            meta_prev, body_prev = _parse_md(group_path)
+            files_prev = ast.literal_eval(meta_prev.get("files", "[]")) if "files" in meta_prev else []
+            files = files_prev + files
+            meta_prev.update(meta)
+            meta_prev["files"] = files
+            meta = meta_prev
+            text = body_prev or text
+    path = group_path or subdir / f"{msg.id}.md"
+    _write_md(path, meta, text)
     log.debug("Wrote message", path=str(path))
 
 

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import sys
 import types
 import importlib
+import asyncio
+import datetime
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -22,3 +24,64 @@ def test_get_last_id(tmp_path, monkeypatch):
     (chat_dir / "1.md").write_text("msg1")
     (chat_dir / "3.md").write_text("msg3")
     assert tg_client.get_last_id(chat) == 3
+
+
+class DummyMessage:
+    def __init__(self, msg_id, date, grouped_id=None, text="", media=False):
+        self.id = msg_id
+        self.date = date
+        self.grouped_id = grouped_id
+        self.message = text
+        self.media = media
+        self.sender_id = 1
+        self.reply_to_msg_id = None
+        if media:
+            self.file = types.SimpleNamespace(ext=".jpg", name="img.jpg")
+        else:
+            self.file = None
+
+    async def download_media(self, *_):
+        return b"data"
+
+    async def get_sender(self):
+        return types.SimpleNamespace(
+            first_name="John",
+            last_name="Doe",
+            username="john",
+            phone="123",
+        )
+
+
+def fake_get_permissions(chat, user):
+    return types.SimpleNamespace(is_admin=False)
+
+
+def test_grouped_message(tmp_path, monkeypatch):
+    async def run():
+        cfg = types.ModuleType("config")
+        cfg.TG_API_ID = 0
+        cfg.TG_API_HASH = ""
+        cfg.TG_SESSION = ""
+        cfg.CHATS = []
+        monkeypatch.setitem(sys.modules, "config", cfg)
+        tg_client = importlib.import_module("tg_client")
+
+        monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path)
+        monkeypatch.setattr(tg_client, "MEDIA_DIR", tmp_path / "media")
+
+        client = types.SimpleNamespace(get_permissions=fake_get_permissions)
+
+        date = datetime.datetime(2024, 5, 1)
+        msg1 = DummyMessage(1, date, grouped_id=10, text="hello", media=True)
+        msg2 = DummyMessage(2, date, grouped_id=10, media=True)
+
+        await tg_client._save_message(client, "chat", msg1)
+        await tg_client._save_message(client, "chat", msg2)
+
+        chat_dir = tmp_path / "chat" / "2024" / "05"
+        files = list(chat_dir.glob("*.md"))
+        assert len(files) == 1
+        content = files[0].read_text()
+        assert "files" in content
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- keep more info about message authors
- group album messages in one Markdown file and remove "View original post"
- document new metadata fields
- test grouped message handling

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a8efc94c8324a537287e46f8ec66