### PR TITLE
Implement incremental message pulling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Batumarket
 
-Tools for mirroring Telegram "Барахолка" style chats and building a small AI powered marketplace.  The parser now uses [Telethon](https://github.com/LonamiWebs/Telethon) to operate a normal user account.  Each service is a Python script invoked from the Makefile at the repository root.
+Tools for mirroring Telegram "Барахолка" style chats and building a small AI powered marketplace.  The parser now uses [Telethon](https://github.com/LonamiWebs/Telethon) to operate a normal user account.  Message history is fetched incrementally with a 31 day cap so the initial sync finishes quickly.  Each service is a Python script invoked from the Makefile at the repository root.
 
 See [docs/services.md](docs/services.md) for an overview of the scripts.
 For installation instructions see [docs/setup.md](docs/setup.md).

--- a/docs/services.md
+++ b/docs/services.md
@@ -5,9 +5,11 @@ This repository powers a small Telegram marketplace.  Each Python script in
 [`setup.md`](setup.md) for installation instructions.
 
 ## tg_client.py
-Uses Telethon to mirror the target chats as a normal user account.  On start it
-fetches all messages newer than the last saved ID for each chat before
-listening for real‑time updates.  Incoming messages are stored as Markdown under
+Uses Telethon to mirror the target chats as a normal user account.  The client
+advances the history gradually: on each run it fetches at most one additional
+day of messages and never goes further than 31 days into the past.  After the
+initial catch‑up it listens for real‑time updates.  Incoming messages are stored
+as Markdown under
 `data/raw/<chat>/<year>/<month>/<id>.md` with basic metadata at the top.  Media
 files are placed next to a `.md` description under
 `data/media/<chat>/<year>/<month>/` using their SHA‑256 hash plus extension.

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -6,7 +6,18 @@ import importlib
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
+def _install_telethon_stub(monkeypatch):
+    tl_custom = types.ModuleType("telethon.tl.custom")
+    tl_custom.Message = object
+    telethon = types.ModuleType("telethon")
+    telethon.TelegramClient = object
+    telethon.events = types.SimpleNamespace(NewMessage=object, MessageEdited=object)
+    monkeypatch.setitem(sys.modules, "telethon", telethon)
+    monkeypatch.setitem(sys.modules, "telethon.tl.custom", tl_custom)
+
+
 def test_get_last_id(tmp_path, monkeypatch):
+    _install_telethon_stub(monkeypatch)
     cfg = types.ModuleType("config")
     cfg.TG_API_ID = 0
     cfg.TG_API_HASH = ""
@@ -22,3 +33,66 @@ def test_get_last_id(tmp_path, monkeypatch):
     (chat_dir / "1.md").write_text("msg1")
     (chat_dir / "3.md").write_text("msg3")
     assert tg_client.get_last_id(chat) == 3
+
+
+class _DummyMessage:
+    def __init__(self, mid, date):
+        self.id = mid
+        self.date = date
+        self.message = ""
+        self.media = None
+        self.reply_to_msg_id = None
+        self.sender_id = 1
+
+
+class _DummyClient:
+    def __init__(self, msgs):
+        self._msgs = msgs
+
+    def iter_messages(self, chat, min_id=None, reverse=True):
+        async def gen():
+            for m in self._msgs:
+                if min_id and m.id <= min_id:
+                    continue
+                yield m
+        return gen()
+
+    async def get_permissions(self, chat, user_id):
+        return types.SimpleNamespace(is_admin=False)
+
+
+import asyncio
+from datetime import datetime, timedelta
+
+
+def test_fetch_missing_day_limit(tmp_path, monkeypatch):
+    _install_telethon_stub(monkeypatch)
+    cfg = types.ModuleType("config")
+    cfg.TG_API_ID = 0
+    cfg.TG_API_HASH = ""
+    cfg.TG_SESSION = ""
+    cfg.CHATS = ["chat"]
+    monkeypatch.setitem(sys.modules, "config", cfg)
+    tg_client = importlib.reload(importlib.import_module("tg_client"))
+
+    monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path / "raw")
+
+    now = datetime.utcnow()
+    start = now - timedelta(days=31)
+    msgs = [
+        _DummyMessage(1, start + timedelta(hours=1)),
+        _DummyMessage(2, start + timedelta(hours=20)),
+        _DummyMessage(3, start + timedelta(hours=25)),
+    ]
+    client = _DummyClient(msgs)
+
+    saved = []
+
+    async def save_stub(_c, _chat, msg):
+        saved.append(msg.id)
+
+    monkeypatch.setattr(tg_client, "_save_message", save_stub)
+
+    asyncio.run(tg_client.fetch_missing(client))
+
+    assert saved == [1, 2]


### PR DESCRIPTION
## Summary
- limit history sync to one day at a time and skip messages older than 31 days
- update service docs and README for new pull behaviour
- add regression tests for the new logic

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ab2153148324b610916fa916ff60