### PR TITLE
Fix timezone deprecation

### DIFF
--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import ast
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from telethon import TelegramClient, events
 from telethon.tl.custom import Message
@@ -164,7 +164,7 @@ async def ensure_chat_access(client: TelegramClient) -> None:
 
 async def fetch_missing(client: TelegramClient) -> None:
     """Pull new messages advancing at most one day per run."""
-    cutoff = datetime.utcnow() - timedelta(days=31)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=31)
     for chat in CHATS:
         last_id = get_last_id(chat)
         start_date = cutoff
@@ -182,7 +182,7 @@ async def fetch_missing(client: TelegramClient) -> None:
                         except ValueError:
                             pass
                         break
-        end_date = min(datetime.utcnow(), start_date + timedelta(days=1))
+        end_date = min(datetime.now(timezone.utc), start_date + timedelta(days=1))
         count = 0
         async for msg in client.iter_messages(chat, min_id=last_id, reverse=True):
             if msg.date < start_date:

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -110,7 +110,7 @@ def test_fetch_missing_day_limit(tmp_path, monkeypatch):
     tg_client = importlib.reload(importlib.import_module("tg_client"))
     monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path / "raw")
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     start = now - datetime.timedelta(days=31)
     msgs = [
         _DummyMessage(1, start + datetime.timedelta(hours=1)),


### PR DESCRIPTION
## Summary
- switch tg_client to timezone-aware datetimes
- update tests for new API

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854aec57bd08324984ea3a64c584ffe