### PR TITLE
Improve tg_client logging and reliability

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -16,6 +16,10 @@ Uses Telethon to mirror the target chats as a normal user account.
   last stored ID.
 * **Realtime updates.** Once the historical backlog is caught up the client
   switches to listening for live events.
+* **Multiple sessions.** The Telegram client runs with ``sequential_updates=True``
+  so several sessions can use the same account without missing events.
+* **Heartbeat.** A background task logs a ``Heartbeat`` message every minute and
+  warns if no updates arrive for more than five minutes.
 * **Storage layout.** Incoming messages are saved as Markdown under
   `data/raw/<chat>/<year>/<month>/<id>.md` with basic metadata at the top.
   Media files live beside a `.md` description in


### PR DESCRIPTION
## Summary
- add periodic heartbeat logging and warn on long idle time
- run Telethon client with `sequential_updates` for multi-session safety
- document heartbeat and multi-session behavior
- test that `main` passes the new option to TelegramClient

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b3d0ad7c83248a90c17e64bad795