### PR TITLE
Improve Telegram history sync

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -10,10 +10,11 @@ Uses Telethon to mirror the target chats as a normal user account.
 * **Chat access.** At startup the client checks that the account has already
   joined every chat listed in `CHATS`, joining any missing private channels so
   their history is accessible.
-* **Back-fill strategy.** If a chat still has less than 31 days of history on
-  disk, each run back-fills **at most one additional day** by requesting
-  messages older than the earliest stored ID.  Once a full month is present on
-  disk the client only fetches messages newer than the last stored ID.
+* **Back-fill strategy.** The client keeps only the last month on disk.  When
+  fetching history it jumps straight to the cut-off date instead of scrolling
+  from the very first message.  If less than 31 days are stored each run
+  back-fills **at most one additional day**; once a full month is present only
+  newer messages are pulled.
 * **Realtime updates.** Once the historical backlog is caught up the client
   switches to listening for live events.
 * **Multiple sessions.** The Telegram client runs with ``sequential_updates=True``

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -234,9 +234,7 @@ async def fetch_missing(client: TelegramClient) -> None:
             start_date = cutoff if first_date is None else max(cutoff, first_date - timedelta(days=1))
             end_date = min(first_date or now, start_date + timedelta(days=1))
             count = 0
-            async for msg in client.iter_messages(chat, max_id=(first_id or None), reverse=True):
-                if msg.date < start_date:
-                    continue
+            async for msg in client.iter_messages(chat, offset_date=start_date, reverse=True):
                 if msg.date >= end_date:
                     break
                 path = RAW_DIR / chat / f"{msg.date:%Y}" / f"{msg.date:%m}" / f"{msg.id}.md"

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -90,7 +90,7 @@ class _DummyClient:
     def __init__(self, msgs):
         self._msgs = msgs
 
-    def iter_messages(self, chat, min_id=None, max_id=None, reverse=True):
+    def iter_messages(self, chat, min_id=None, max_id=None, reverse=True, offset_date=None):
         async def gen():
             msgs = sorted(self._msgs, key=lambda m: m.date)
             if not reverse:
@@ -99,6 +99,8 @@ class _DummyClient:
                 if min_id is not None and m.id <= min_id:
                     continue
                 if max_id is not None and m.id >= max_id:
+                    continue
+                if offset_date is not None and m.date <= offset_date:
                     continue
                 yield m
 


### PR DESCRIPTION
## Summary
- scroll to last month directly via `offset_date`
- note the strategy change in docs
- update tests for new parameter

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b90fa2e4832481bd8313e80ab359