### PR TITLE
Improve tg_client download logging

### DIFF
--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -262,7 +262,7 @@ class DummyMessage:
         else:
             self.file = None
 
-    async def download_media(self, *_):
+    async def download_media(self, *_, **__):
         return b"data"
 
     async def get_sender(self):
@@ -324,7 +324,7 @@ def test_save_message_skip_missing_media(tmp_path, monkeypatch):
         monkeypatch.setattr(tg_client, "MEDIA_DIR", tmp_path / "media")
 
         class NoData(DummyMessage):
-            async def download_media(self, *_):
+            async def download_media(self, *_, **__):
                 return None
 
         client = types.SimpleNamespace(get_permissions=fake_get_permissions)


### PR DESCRIPTION
## Summary
- add progress-logging and timeout to Telegram downloads
- include message/file info in logs
- adjust tests for new `download_media` call

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854c0faa0088324964877f1d97fe239