### PR TITLE
Document AI costs and avoid duplicate processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Tools for mirroring Telegram "Барахолка" style chats and building a sma
 See [docs/services.md](docs/services.md) for an overview of the scripts.
 For installation instructions see [docs/setup.md](docs/setup.md).
 The project goals are described in [docs/vision.md](docs/vision.md).
+Approximate OpenAI expenses are outlined in [docs/costs.md](docs/costs.md).
 
 Logs are written to `errors.log` in JSON format. Set the `LOG_LEVEL`
 environment variable to `DEBUG`, `INFO` or `ERROR` to adjust verbosity.

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -1,0 +1,29 @@
+# Estimated Daily AI Costs
+
+This document provides a rough overview of how much it costs to process one day worth of data with the default OpenAI models.
+
+## Daily Input
+- **Images**: ~1&nbsp;GB of photos (~1000 images).
+- **Text**: ~3&nbsp;MB of Telegram messages (~750k tokens).
+
+## Captioning
+Each image is sent to GPT‑4o with a short prompt. A single 1080 × 1080 photo counts for roughly 85 input tokens. With about 20 tokens of prompt and ~100 tokens in the response the total cost per image is around 225 tokens.
+
+- **Input**: 125k tokens → `125k / 1M × $5 ≈ $0.63`
+- **Output**: 100k tokens → `100k / 1M × $15 ≈ $1.50`
+
+**Captioning total:** ~$2.1 per day.
+
+## Chopping Posts
+`chop.py` uses GPT‑4o to split messages into lots. The message text plus image captions add up to roughly 850k input tokens per day. The JSON output is about 100k tokens.
+
+- **Input**: `850k / 1M × $5 ≈ $4.25`
+- **Output**: `100k / 1M × $15 ≈ $1.50`
+
+**Chopping total:** ~$5.8 per day.
+
+## Embedding
+Lots are embedded with `text-embedding-3-large`. At about 100k tokens per day the cost is negligible (`100k / 1M × $0.13 ≈ $0.013`).
+
+## Grand Total
+Roughly **$8 per day** for OpenAI API calls when processing 1&nbsp;GB of images and 3&nbsp;MB of text. Multiply by 30 for a monthly estimate of about **$240**. Costs can be reduced by skipping unchanged messages or batching updates less frequently.

--- a/docs/services.md
+++ b/docs/services.md
@@ -52,7 +52,7 @@ lots.  Output is a JSON file per message in `data/lots` ready for further
 processing.
 
 ## embed.py
-Generates `text-embedding-4o` vectors for each lot.  Vectors are stored both in
+Generates `text-embedding-3-large` vectors for each lot.  Vectors are stored both in
 `data/vectors.jsonl` and in the `lot_vec` table using pgvector.
 
 Translations are now produced by `chop.py` itself.  Fields like

--- a/src/chop.py
+++ b/src/chop.py
@@ -31,6 +31,11 @@ SYSTEM_PROMPT = (
 
 
 def process_message(msg_path: Path) -> None:
+    out = LOTS_DIR / msg_path.name.replace(".md", ".json")
+    if out.exists():
+        log.debug("Skipping existing lot file", path=str(out))
+        return
+
     text = read_md(msg_path)
     captions = []
     for sha_path in MEDIA_DESC.glob("*.md"):
@@ -48,7 +53,6 @@ def process_message(msg_path: Path) -> None:
     except Exception:
         log.exception("Failed to chop", file=str(msg_path))
         return
-    out = LOTS_DIR / msg_path.name.replace(".md", ".json")
     out.write_text(json.dumps(lots, ensure_ascii=False, indent=2))
     log.debug("Wrote", path=str(out))
 

--- a/src/embed.py
+++ b/src/embed.py
@@ -31,9 +31,16 @@ CREATE TABLE IF NOT EXISTS lot_vec(
 
 
 def embed_text(lot_id: str, text: str, cur) -> None:
+    cur.execute("SELECT 1 FROM lot_vec WHERE lot_id = %s", [lot_id])
+    if cur.fetchone():
+        log.debug("Vector already stored", id=lot_id)
+        return
+
     log.debug("Embedding", id=lot_id, tokens=estimate_tokens(text))
     try:
-        resp = openai.embeddings.create(model="text-embedding-4o", input=text)
+        resp = openai.embeddings.create(
+            model="text-embedding-3-large", input=text
+        )
         vec = resp.data[0].embedding
     except Exception:
         log.exception("Embed failed", id=lot_id)


### PR DESCRIPTION
## Summary
- document approximate OpenAI expenses
- link the cost doc from the README
- skip already processed messages in `chop.py`
- avoid re-embedding lots that already exist
- switch to `text-embedding-3-large` to fix invalid model name

## Testing
- `make precommit`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6854d9bc353c8324995215b8c64a7335