### PR TITLE
Improve chopper schema prompt

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -46,6 +46,9 @@ Calls GPT-4o Vision to caption the images in `data/media`.  The result is stored
 under `data/media_desc/<sha>.md`.  Captions are later included in the lot
 chopper prompt.
 
+See [chopper_prompt.md](../prompts/chopper_prompt.md) for the schema and taxonomy used by the
+lot chopper.
+
 ## chop.py
 Feeds the message text plus any media captions to GPT-4o to extract individual
 lots.  Output is a JSON file per message in `data/lots` ready for further

--- a/prompts/chopper_prompt.md
+++ b/prompts/chopper_prompt.md
@@ -1,0 +1,57 @@
+# Chopper Blueprint
+
+The lot chopper uses GPT-4o to transform raw posts into structured JSON. The
+API request sets `response_format=json_object`, so replies **must** be pure JSON
+with no code fences or explanations.  This document summarizes the schema and
+message taxonomy expected from the model.
+
+## Schema
+The output is a flat dictionary inspired by OpenStreetMap tags. Important keys include:
+
+- `market:deal` – main intent such as `rent_out`, `rent_seek`, `sell`, `buy`, `services`.
+- `property:type` – e.g. `apartment`, `apartment_studio`, `house`, `room`, `land`, `commercial`.
+- `rooms` – "studio" or integer as a string.
+- `area` – integer square metres when available.
+- `price`, `price:currency`, `price:period` – normalised price fields.
+- `pets` – `yes`, `no`, `cat_only`, etc.
+- `view` – `sea`, `mountain`, `city`, `courtyard`, ...
+- `heating` – `central`, `gas`, `electric`, `none`.
+- `gas` – whether a gas pipe is mentioned.
+- `addr:street`, `addr:housenumber` – greedy street and number match.
+- `building:name` – named apartment blocks.
+- `floor`, `building:levels` – floor number and total floors.
+- `furnishing` – `furnished`, `part`, `none`.
+- `contact:phone`, `contact:telegram` – stripped to digits or `@username`.
+
+Additional nuggets like parking, balcony or urgency can be added as they appear. Only include keys you are confident about; omit unknown fields to keep the JSON lean.
+
+## Taxonomy
+- **Real-estate** – `rent_out_long`, `rent_out_short`, `rent_seek`, `sell_property`, `buy_property`, `exchange`.
+  Required keys: `property:type`, `rooms`/`area`, `price`, `price:period`, `view`, `pets`, `addr:*`.
+- **Goods** – `sell_item`, `buy_item`.
+  Keys: `item:type`, `brand`, `condition`, `price`, `price:currency`, `urgency`.
+- **Jobs / Services** – `job_offer`, `job_seek`, `services_offer`, `services_seek`.
+  Keys: `occupation`, `salary`, `currency`, `schedule`, `remote`, `contact:*`.
+- **Community / Events** – `event_invite`, `event_seek`, `announcement`.
+  Keys: `event:type`, `date`, `location`, `fee`, `contact:*`.
+- Anything outside these groups should be placed under `misc` until patterns emerge.
+
+## Example
+```json
+{
+  "source:chat": "domikibatumi",
+  "source:message_id": "540471",
+  "timestamp": "2025-05-20T11:41:34+00:00",
+  "market:deal": "rent_out",
+  "property:type": "apartment",
+  "rooms": "2",
+  "price": 450,
+  "price:currency": "USD",
+  "pets": "no",
+  "addr:street": "Кобаладзе",
+  "addr:housenumber": "8а",
+  "building:name": "Orbi City",
+  "heating": "central",
+  "view": "sea"
+}
+```

--- a/src/chop.py
+++ b/src/chop.py
@@ -1,4 +1,9 @@
-"""Split telegram messages into lots with GPT-4o."""
+"""Split Telegram messages into lots using GPT-4o.
+
+The system prompt is built from ``prompts/chopper_prompt.md`` which details the
+expected JSON schema and message taxonomy.  Any change to that file immediately
+affects the extraction logic.
+"""
 
 import json
 from pathlib import Path
@@ -12,6 +17,9 @@ OPENAI_KEY = cfg.OPENAI_KEY
 LANGS = cfg.LANGS
 from log_utils import get_logger, install_excepthook
 from notes_utils import read_md
+
+# Blueprint describing expected fields and message taxonomy used by the model.
+BLUEPRINT = Path("prompts/chopper_prompt.md").read_text(encoding="utf-8")
 from token_utils import estimate_tokens
 
 log = get_logger().bind(script=__file__)
@@ -23,10 +31,15 @@ RAW_DIR = Path("data/raw")
 MEDIA_DESC = Path("data/media_desc")
 LOTS_DIR = Path("data/lots")
 
+# System prompt appended to the blueprint.  Explicitly instruct the model to
+# respond with *only* JSON, no code fences or extra text.  The API request will
+# also enforce this via ``response_format``.
 SYSTEM_PROMPT = (
-    "You will receive a raw marketplace post with optional image captions.\n"
+    BLUEPRINT
+    + "\n\nYou will receive a raw marketplace post with optional image captions.\n"
     "Return a JSON list of separate lots with media SHA references.\n"
-    "For each of these languages: {langs}, produce title_<lang> and description_<lang> fields."
+    "For each of these languages: {langs}, produce title_<lang> and description_<lang> fields.\n"
+    "Respond with JSON only."
 )
 
 
@@ -42,13 +55,22 @@ def process_message(msg_path: Path) -> None:
         captions.append(read_md(sha_path))
     prompt = text + "\n" + "\n".join(captions)
     system_prompt = SYSTEM_PROMPT.format(langs=", ".join(LANGS))
+    log.debug("Blueprint tokens", count=estimate_tokens(BLUEPRINT))
+    log.debug("System prompt tokens", count=estimate_tokens(system_prompt))
     messages = [
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": prompt},
     ]
     log.debug("Prompt tokens", count=estimate_tokens(prompt), langs=LANGS)
     try:
-        resp = openai.chat.completions.create(model="gpt-4o", messages=messages)
+        # ``response_format`` ensures GPT-4o emits a valid JSON object with no
+        # extra text.  ``temperature`` 0 keeps the output deterministic.
+        resp = openai.chat.completions.create(
+            model="gpt-4o",
+            messages=messages,
+            response_format={"type": "json_object"},
+            temperature=0,
+        )
         lots = json.loads(resp.choices[0].message.content)
     except Exception:
         log.exception("Failed to chop", file=str(msg_path))


### PR DESCRIPTION
## Summary
- document schema and taxonomy used for the lot chopper
- link new documentation from the service overview
- build chopper prompt from that blueprint and log token counts
- moved chopper prompt to `prompts/` and enforced JSON-only responses

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ea54a428832490a726a073caf260