### PR TITLE
Refine Makefile pipeline dependencies

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -73,5 +73,6 @@ to all subscribers when new lots are detected.
 
 ## Makefile
 The `Makefile` in the repository root wires these scripts together.  Running
-`make update` performs a full refresh: pulling messages, captioning images,
-chopping, embedding and rebuilding the static site.
+`make compose` performs a full refresh: pulling messages, captioning images,
+chopping, embedding and rebuilding the static site.  `make update` is kept as a
+compatibility alias for older instructions.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,8 +38,10 @@ variables before running any script:
 Use the Makefile in the repository root to run the pipeline:
 
 ```bash
-make update
+make compose
 ```
+
+`make update` continues to work as an alias for this pipeline.
 
 This pulls messages, captions images, chops lots, generates embeddings and finally builds the static site.
 


### PR DESCRIPTION
## Summary
- define new `compose` target and chain steps with dependencies
- document `compose` in setup and services documentation

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f4bb43f88324878faa8da4673b61