### PR TITLE
Update caption workflow

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -44,8 +44,11 @@ Metadata fields include at least:
 ## caption.py
 Calls GPT-4o Vision using the instructions in
 [`captioner_prompt.md`](../prompts/captioner_prompt.md) to describe each photo in
-`data/media`.  Every image gets a companion `*.caption.md` file stored beside the
-original.  Captions are later included in the lot chopper prompt. When
+`data/media`. Images are processed from newest to oldest. Before sending to the
+API every picture is scaled so the shorter side equals 512&nbsp;px, then
+ImageMagick's liquid rescale squeezes it down to `512x512` without cropping.
+Each processed image gets a companion `*.caption.md` file stored beside the
+original. Captions are later included in the lot chopper prompt. When
 `LOG_LEVEL` is set to `INFO`, the script logs each processed filename along with
 the generated caption.
 


### PR DESCRIPTION
## Summary
- process media newest to oldest
- resize images to 512px on the short side, liquid rescale to 512x512 before captioning
- document the new captioning behaviour

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_6854fb7548148324998b73e18d2893d9