### PR TITLE
Refactor captioner to work with GNU Parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ pull:
 
 # Generate image captions after pulling media.
 caption: pull
-	$(PYTHON) src/caption.py
+	find data/media -type f ! -name '*.md' -printf '%T@ %p\0' \
+	        | sort -z -nr \
+	        | cut -z -d' ' -f2- \
+	        | parallel -0 $(PYTHON) src/caption.py
 
 # Split messages into lots using captions and message text.
 chop: caption

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Approximate OpenAI expenses are outlined in [docs/costs.md](docs/costs.md).
 
 Logs are written to `errors.log` in JSON format. Set the `LOG_LEVEL`
 environment variable to `DEBUG`, `INFO` or `ERROR` to adjust verbosity.
-Running `caption.py` with `LOG_LEVEL=INFO` records the processed filename and
-the generated caption for easier debugging.
+Running `make caption` with `LOG_LEVEL=INFO` records each processed file and the
+generated caption for easier debugging.

--- a/docs/services.md
+++ b/docs/services.md
@@ -43,10 +43,11 @@ Metadata fields include at least:
 
 ## caption.py
 Calls GPT-4o Vision using the instructions in
-[`captioner_prompt.md`](../prompts/captioner_prompt.md) to describe each photo in
-`data/media`. Images are processed from newest to oldest. Before sending to the
-API every picture is scaled so the shorter side equals 512&nbsp;px, then
-ImageMagick's liquid rescale squeezes it down to `512x512` without cropping.
+[`captioner_prompt.md`](../prompts/captioner_prompt.md) to describe photos from
+`data/media`. The Makefile lists files and runs ``caption.py`` on them using GNU
+Parallel. Before sending to the API every picture is scaled so the shorter side
+equals 512&nbsp;px, then ImageMagick's liquid rescale squeezes it down to
+``512x512`` without cropping.
 Each processed image gets a companion `*.caption.md` file stored beside the
 original. Captions are later included in the lot chopper prompt. When
 `LOG_LEVEL` is set to `INFO`, the script logs each processed filename along with


### PR DESCRIPTION
## Summary
- refactor `caption.py` to accept a single image path
- fall back to original data if ImageMagick fails during resize
- run captioner with GNU Parallel in `make caption`
- document new invocation

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fda8cd108324972eeb5a38424e1c