### PR TITLE
Clarify captions in chopper prompt

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -52,9 +52,11 @@ parallel. Before sending to the API every picture is scaled so the shorter side
 equals 512&nbsp;px, then ImageMagick's liquid rescale squeezes it down to
 ``512x512`` without cropping.
 Each processed image gets a companion `*.caption.md` file stored beside the
-original. Captions are later included in the lot chopper prompt. When
-`LOG_LEVEL` is set to `INFO`, the script logs each processed filename along with
-the generated caption.
+original. Captions are later included in the lot chopper prompt where the
+`chop.py` script lists every `Image <filename>` before its caption. This makes
+it crystal clear which picture the text belongs to. When `LOG_LEVEL` is set to
+`INFO`, the script logs each processed filename along with the generated
+caption.
 If some captions are missing you can run `make caption` to retry processing
 all images.
 
@@ -63,9 +65,11 @@ lot chopper.
 
 ## chop.py
 Feeds the message text plus any media captions to GPT-4o to extract individual
-lots.  The script walks `data/raw/<chat>/<year>/<month>` recursively and logs
-how many posts were processed.  Output is a JSON file per message in
-`data/lots` ready for further processing.
+lots. `chop.py` marks the start of the original message with `Message text:` so
+the LLM does not confuse it with captions. Each caption is preceded by its
+filename. The script walks `data/raw/<chat>/<year>/<month>` recursively and logs
+how many posts were processed. Output is a JSON file per message in `data/lots`
+ready for further processing.
 
 ## embed.py
 Generates `text-embedding-3-large` vectors for each lot.  Vectors are stored both in

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -6,7 +6,7 @@ Components involved:
 
 - **Database** – a git repository containing Markdown and images from the ads. It should be easy to update and consume new data.
 - **Telegram bot** – monitors configured chats and saves raw messages and photos. Deleted or sold items are marked based on Telegram edits.
-- **Chopper** – splits posts into individual lots, pairing images with the correct text fragments. The result is a machine‑readable JSON inspired by OpenStreetMap tags while keeping links to the original message. OpenAI APIs are used here.
+- **Chopper** – splits posts into individual lots, pairing images with the correct text fragments. Captions are passed as `Image <filename>` blocks so the model knows which picture is which. The result is a machine‑readable JSON inspired by OpenStreetMap tags while keeping links to the original message. OpenAI APIs are used here.
 - **Indexer** – generates embeddings for each lot to enable search and "similar items" suggestions.
 - **Browser** – renders the database as static HTML so it is easily crawled by search engines.
 - **Alerter** – notifies subscribers on Telegram when new lots match their interests. The same bot can be reused for alerts.

--- a/src/chop.py
+++ b/src/chop.py
@@ -35,6 +35,16 @@ LOTS_DIR = Path("data/lots")
 IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
 
+def _build_prompt(text: str, files: list[str], captions: list[str]) -> str:
+    """Return prompt combining message text with captioned file names."""
+    parts = []
+    if text.strip():
+        parts.append(f"Message text:\n{text.strip()}")
+    for file, caption in zip(files, captions):
+        parts.append(f"Image {file}:\n{caption.strip()}")
+    return "\n\n".join(parts)
+
+
 def _parse_md(path: Path) -> tuple[dict, str]:
     """Return metadata dict and message text."""
     text = path.read_text(encoding="utf-8") if path.exists() else ""
@@ -84,10 +94,12 @@ def process_message(msg_path: Path) -> None:
             if not cap.exists():
                 log.info("Skipping message", path=str(msg_path), reason="missing-caption", file=str(p))
                 return
-            captions.append(read_md(cap))
+            caption_text = read_md(cap)
+            log.debug("Found caption", file=str(p), text=caption_text)
+            captions.append(caption_text)
     # Combine the original message text with image captions. This ensures GPT
     # has full context rather than captions alone.
-    prompt = text + ("\n" + "\n".join(captions) if captions else "")
+    prompt = _build_prompt(text, files, captions)
     system_prompt = SYSTEM_PROMPT.replace("{langs}", ", ".join(LANGS))
     log.debug("Blueprint tokens", count=estimate_tokens(BLUEPRINT))
     log.debug("System prompt tokens", count=estimate_tokens(system_prompt))

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -33,3 +33,13 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     chop.main()
 
     assert (tmp_path / "lots" / "1.json").exists()
+
+
+def test_build_prompt():
+    msg = "hello"
+    files = ["a.jpg", "b.jpg"]
+    caps = ["cap a", "cap b"]
+    prompt = chop._build_prompt(msg, files, caps)
+    assert "Message text:" in prompt
+    assert "Image a.jpg" in prompt
+    assert "cap a" in prompt


### PR DESCRIPTION
## Summary
- label the message text in `chop.py`
- prefix each caption with its filename when building the prompt
- document how captions are associated with images
- describe chopper improvements in the vision doc
- test the new `_build_prompt` helper

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551092023483249f48432b9bb9ea8c