### PR TITLE
Update chopper output paths and prompts

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -68,8 +68,8 @@ Feeds the message text plus any media captions to GPT-4o to extract individual
 lots. `chop.py` marks the start of the original message with `Message text:` so
 the LLM does not confuse it with captions. Each caption is preceded by its
 filename. The script walks `data/raw/<chat>/<year>/<month>` recursively and logs
-how many posts were processed. Output is a JSON file per message in `data/lots`
-ready for further processing. The API call now specifies
+how many posts were processed. Output is a JSON file per message mirroring the
+same chat/year/month layout under `data/lots`. The API call now specifies
 `response_format={"type": "json_object"}` so GPT-4o returns plain JSON without
 Markdown wrappers.
 
@@ -78,7 +78,9 @@ Generates `text-embedding-3-large` vectors for each lot.  Vectors are stored bot
 `data/vectors.jsonl` and in the `lot_vec` table using pgvector.
 
 Translations are now produced by `chop.py` itself.  Fields like
-`title_ru` or `description_ka` are included in the lot JSON directly.
+`title_ru` or `description_ka` are included in the lot JSON directly. Titles
+use the street name together with room count, floor level and view where
+applicable so that every language has a meaningful summary.
 
 ## build_site.py
 Uses Jinja templates from the `templates/` directory to render the static HTML

--- a/prompts/chopper_prompt.md
+++ b/prompts/chopper_prompt.md
@@ -24,8 +24,11 @@ The output is a flat dictionary inspired by OpenStreetMap tags. Important keys i
 - `furnishing` – `furnished`, `part`, `none`.
 - `washing_machine`, `dishwasher`, `computer_table`, `stove`, `oven`, `bath`, `shower`, `sofa`, `wifi` ... – `yes`, `no`, null/skip.
 - `contact:phone`, `contact:telegram` – stripped to digits in full international format or `@username`.
+- `files` – list of stored media paths for the lot.
 
 Additional nuggets like parking, balcony or urgency can be added as they appear. Only include keys you are confident about; omit unknown fields to keep the JSON lean.
+
+Craft `title_<lang>` and `description_<lang>` for every lot using both the original text and image captions. Use the street name along with the number of rooms, floor level and view to form concise titles for real-estate posts. Ensure these fields are filled for all languages requested in the prompt.
 
 ## Taxonomy
 - **Real-estate** – `rent_out_long`, `rent_out_short`, `rent_seek`, `sell_property`, `buy_property`, `exchange`.
@@ -56,7 +59,7 @@ Additional nuggets like parking, balcony or urgency can be added as they appear.
     "building:name": "Orbi City",
     "heating": "central",
     "view": "sea",
-    "media": [
+    "files": [
       "arenda_batumi/2025/05/39e69dc40820bdc9b749f9dbe1a621a6900acc7d0c9b7afc453c539c235d5341.jpg"
     ]
   }

--- a/src/chop.py
+++ b/src/chop.py
@@ -67,14 +67,16 @@ def _parse_md(path: Path) -> tuple[dict, str]:
 SYSTEM_PROMPT = (
     BLUEPRINT
     + "\n\nYou will receive a raw marketplace post with optional image captions.\n"
-    "Return a JSON array of separate lots with media references.\n"
+    "Return a JSON array of separate lots with file references.\n"
     "For each of these languages: {langs}, produce title_<lang> and description_<lang> fields.\n"
     "Respond with JSON only. Do not use code fences or any extra text."
 )
 
 
 def process_message(msg_path: Path) -> None:
-    out = LOTS_DIR / msg_path.name.replace(".md", ".json")
+    rel = msg_path.relative_to(RAW_DIR)
+    out = LOTS_DIR / rel.with_suffix(".json")
+    out.parent.mkdir(parents=True, exist_ok=True)
     if out.exists():
         log.debug("Skipping existing lot file", path=str(out))
         return

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -36,7 +36,7 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
 
     chop.main()
 
-    assert (tmp_path / "lots" / "1.json").exists()
+    assert (tmp_path / "lots" / "chat" / "2024" / "05" / "1.json").exists()
     assert called.get("response_format") == {"type": "json_object"}
 
 


### PR DESCRIPTION
## Summary
- store chopped lots under the same path layout as source posts
- keep only `files` in example schema and expand chopper instructions
- explain new output layout and title rules in docs
- adjust test for nested output path

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551685aaa083249b593ddafa7f3678