### PR TITLE
Skip old Telegram media

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -30,8 +30,8 @@ Uses Telethon to mirror the target chats as a normal user account.
 * **Resume state.** The timestamp of the last processed batch is stored under
   `data/state/<chat>.txt` so interrupted runs continue from the same point.
   Attachments that fail to download are skipped with a warning.  The client
-  ignores videos (`.mp4`), audio files and images larger than ten megabytes
-  entirely.
+  ignores videos (`.mp4`), audio files, images larger than ten megabytes and
+  any media attached to messages more than two days old.
 
 Metadata fields include at least:
 


### PR DESCRIPTION
## Summary
- avoid media downloads for messages older than two days
- document the new behaviour
- test skipping of old media

## Testing
- `find src -name '*.py' -print0 | xargs -0 scripts/check_python.sh`
- `pytest -q`
- `TEST_MODE=1 PYTHONPATH=. make -B -j compose` *(fails: ModuleNotFoundError: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_68551ab943b08324a99c518c36a8cf95