### PR TITLE
Add lots ontology collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON=python
 
 # Define pipeline stages explicitly so ``make -j compose`` executes them in the
 # correct order.  Each stage runs only after its dependency completes.
-.PHONY: compose update pull caption chop embed build alert clean precommit
+.PHONY: compose update pull caption chop embed build alert ontology clean precommit
 
 # ``compose`` is the main entry point used by documentation and tests.  ``update``
 # remains as a backwards compatible alias.
@@ -35,6 +35,9 @@ build: embed
 # Telegram alert bot for new lots.
 alert:
 	$(PYTHON) src/alert_bot.py
+
+ontology:
+	$(PYTHON) src/scan_ontology.py
 
 clean:
 	rm -rf data/views/*

--- a/docs/services.md
+++ b/docs/services.md
@@ -93,6 +93,12 @@ as is.
 Simple Telegram bot that lets users subscribe to notifications.  Alerts are sent
 to all subscribers when new lots are detected.
 
+## scan_ontology.py
+Walks through `data/lots` and collects a list of every key used across all
+stored lots.  For each key the script counts how many times each value appears
+and writes the result to `data/ontology.json`.  Run `make ontology` to
+generate the file for manual inspection.
+
 ## Makefile
 The `Makefile` in the repository root wires these scripts together.  Running
 `make compose` performs a full refresh: pulling messages (images are captioned on

--- a/src/scan_ontology.py
+++ b/src/scan_ontology.py
@@ -1,0 +1,52 @@
+"""Scan lot JSONs and record unique keys with value counts."""
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from log_utils import get_logger, install_excepthook
+
+log = get_logger().bind(script=__file__)
+install_excepthook(log)
+
+LOTS_DIR = Path("data/lots")
+OUTPUT_FILE = Path("data/ontology.json")
+
+
+def collect_ontology() -> dict[str, dict[str, int]]:
+    """Return dictionary mapping field names to value counts."""
+    ontology: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    for path in LOTS_DIR.rglob("*.json"):
+        try:
+            lots = json.loads(path.read_text())
+        except Exception:
+            log.exception("Failed to parse", file=str(path))
+            continue
+        if isinstance(lots, dict):
+            lots = [lots]
+        for lot in lots:
+            if not isinstance(lot, dict):
+                continue
+            for key, value in lot.items():
+                if isinstance(value, (dict, list)):
+                    val = json.dumps(value, ensure_ascii=False, sort_keys=True)
+                else:
+                    val = str(value)
+                ontology[key][val] += 1
+    # Convert counters to plain dicts sorted by count
+    result: dict[str, dict[str, int]] = {}
+    for key, counter in ontology.items():
+        result[key] = dict(sorted(counter.items(), key=lambda x: (-x[1], x[0])))
+    return result
+
+
+def main() -> None:
+    log.info("Scanning ontology", path=str(LOTS_DIR))
+    data = collect_ontology()
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    log.info("Wrote ontology", path=str(OUTPUT_FILE))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import json
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import scan_ontology
+
+
+def test_collect_ontology(tmp_path, monkeypatch):
+    monkeypatch.setattr(scan_ontology, "LOTS_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "OUTPUT_FILE", tmp_path / "out.json")
+
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.json").write_text(json.dumps([
+        {"a": 1, "b": "x"},
+        {"a": 2, "b": "x"}
+    ]))
+    (tmp_path / "sub" / "b.json").write_text(json.dumps({"b": "y", "c": [1, 2]}))
+
+    scan_ontology.main()
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["a"] == {"1": 1, "2": 1}
+    assert data["b"] == {"x": 2, "y": 1}
+    assert data["c"] == {"[1, 2]": 1}


### PR DESCRIPTION
## Summary
- introduce `scan_ontology.py` to gather ontology stats from `data/lots`
- provide `make ontology` target
- document ontology scanner
- cover new script with tests

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551b935b788324961744b4a473ed25