### PR TITLE
Refactor chopper to work on single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ caption: pull
 
 # Split messages into lots using captions and message text.
 chop: pull
-	$(PYTHON) src/chop.py
+	find data/raw -name '*.md' -printf '%T@ %p\0' \
+	| sort -z -nr \
+	| cut -z -d' ' -f2- \
+	| parallel -0 $(PYTHON) src/chop.py
 
 # Store embeddings for each lot in Postgres and JSONL.
 embed: chop

--- a/docs/services.md
+++ b/docs/services.md
@@ -67,13 +67,12 @@ lot chopper.
 Feeds the message text plus any media captions to GPT-4o to extract individual
 lots. `chop.py` marks the start of the original message with `Message text:` so
 the LLM does not confuse it with captions. Each caption is preceded by its
-filename. The script walks `data/raw/<chat>/<year>/<month>` recursively and logs
-how many posts were processed. Files are processed from newest to oldest using
-modification timestamps so freshly scraped messages are chopped first. Output is
-a JSON file per message mirroring the same chat/year/month layout under
-`data/lots`. The API call now specifies
-`response_format={"type": "json_object"}` so GPT-4o returns plain JSON without
-Markdown wrappers.
+filename. The script now processes a single Markdown file path provided on the
+command line and writes a matching JSON file under `data/lots`. The Makefile
+collects all message files sorted by modification time and runs `chop.py` for
+each one using GNU Parallel so several messages are processed at once. The API
+call specifies `response_format={"type": "json_object"}` so GPT-4o returns
+plain JSON without Markdown wrappers.
 
 ## embed.py
 Generates `text-embedding-3-large` vectors for each lot.  Vectors are stored both in

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -35,7 +35,7 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     msg.parent.mkdir(parents=True)
     msg.write_text("id: 1\n\nhello", encoding="utf-8")
 
-    chop.main()
+    chop.main([str(msg)])
 
     assert (tmp_path / "lots" / "chat" / "2024" / "05" / "1.json").exists()
     assert called.get("response_format") == {"type": "json_object"}
@@ -51,21 +51,18 @@ def test_build_prompt():
     assert "cap a" in prompt
 
 
-def test_main_sorts_by_mtime(tmp_path, monkeypatch):
+def test_main_cli_argument(tmp_path, monkeypatch):
     monkeypatch.setattr(chop, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(chop, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(chop, "MEDIA_DIR", tmp_path / "media")
 
-    newer = tmp_path / "raw" / "chat" / "2024" / "05" / "2.md"
-    older = tmp_path / "raw" / "chat" / "2024" / "05" / "1.md"
-    for p in (newer, older):
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text("id: x", encoding="utf-8")
-    os.utime(older, (1, 1))
-    os.utime(newer, (2, 2))
+    msg = tmp_path / "raw" / "chat" / "2024" / "05" / "1.md"
+    msg.parent.mkdir(parents=True)
+    msg.write_text("id: x", encoding="utf-8")
 
     processed = []
     monkeypatch.setattr(chop, "process_message", lambda p: processed.append(p))
 
-    chop.main()
-    assert processed == [newer, older]
+    chop.main([str(msg)])
+    assert processed == [msg]
+


### PR DESCRIPTION
## Summary
- take message path as CLI argument
- move file listing to Makefile and run chopper in parallel
- update docs to describe new workflow
- fix tests for new CLI

## Testing
- `make --trace precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551cff558c8324b4769d6d29857609