### PR TITLE
Filter noisy fields from ontology

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -95,8 +95,10 @@ to all subscribers when new lots are detected.
 ## scan_ontology.py
 Walks through `data/lots` and collects a list of every key used across all
 stored lots.  For each key the script counts how many times each value appears
-and writes the result to `data/ontology.json`.  Run `make ontology` to
-generate the file for manual inspection.
+and writes the result to `data/ontology.json`.  After collecting the counts the
+script removes a few noisy fields like timestamps and language specific
+duplicates so the output focuses on meaningful attributes.  Run `make
+ontology` to generate the file for manual inspection.
 
 ## Makefile
 The `Makefile` in the repository root wires these scripts together.  Running

--- a/src/scan_ontology.py
+++ b/src/scan_ontology.py
@@ -12,6 +12,22 @@ install_excepthook(log)
 LOTS_DIR = Path("data/lots")
 OUTPUT_FILE = Path("data/ontology.json")
 
+# Fields that carry volatile per-message metadata or language specific
+# duplicates.  Dropping them keeps ``ontology.json`` focused on the
+# reusable attributes of each lot.
+SKIP_FIELDS = {
+    "timestamp",
+    "contact:telegram",
+    "source:path",
+    "source:message_id",
+    "source:chat",
+    "description_ka",
+    "title_ka",
+    "description_en",
+    "title_en",
+    "files",
+}
+
 
 def collect_ontology() -> dict[str, dict[str, int]]:
     """Return dictionary mapping field names to value counts."""
@@ -43,6 +59,11 @@ def collect_ontology() -> dict[str, dict[str, int]]:
 def main() -> None:
     log.info("Scanning ontology", path=str(LOTS_DIR))
     data = collect_ontology()
+    removed = [f for f in SKIP_FIELDS if f in data]
+    for field in removed:
+        data.pop(field, None)
+    if removed:
+        log.debug("Dropped fields", fields=removed)
     OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2))
     log.info("Wrote ontology", path=str(OUTPUT_FILE))

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -24,3 +24,23 @@ def test_collect_ontology(tmp_path, monkeypatch):
     assert data["a"] == {"1": 1, "2": 1}
     assert data["b"] == {"x": 2, "y": 1}
     assert data["c"] == {"[1, 2]": 1}
+
+
+def test_skip_fields_are_removed(tmp_path, monkeypatch):
+    monkeypatch.setattr(scan_ontology, "LOTS_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "OUTPUT_FILE", tmp_path / "out.json")
+
+    (tmp_path / "a.json").write_text(json.dumps({
+        "timestamp": "now",
+        "contact:telegram": "@user",
+        "files": ["a.jpg"],
+        "other": 5,
+    }))
+
+    scan_ontology.main()
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert "timestamp" not in data
+    assert "contact:telegram" not in data
+    assert "files" not in data
+    assert data["other"] == {"5": 1}


### PR DESCRIPTION
## Summary
- skip noisy metadata fields when writing ontology
- document skipped ontology fields in services guide
- test that skip list is honoured

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555a01bd88832481aac79103bf87c9