### PR TITLE
Enhance static site rendering

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -84,9 +84,13 @@ use the street name together with room count, floor level and view where
 applicable so that every language has a meaningful summary.
 
 ## build_site.py
-Uses Jinja templates from the `templates/` directory to render the static HTML
-version of the marketplace into `data/views`.  The resulting files can be served
-as is.
+Renders the static marketplace website using Jinja templates.  Lots are read
+from `data/lots` and written to `data/views`.  The script loads
+`ontology.json` to order attribute tables and `vectors.jsonl` to suggest
+similar lots.  Each lot page shows images in a small carousel, a table of
+all recognised fields and a link back to the Telegram post.  Pages are
+generated in all languages listed in `config.py` with a simple JavaScript
+switcher.  An index page lists items published during the last week.
 
 ## alert_bot.py
 Simple Telegram bot that lets users subscribe to notifications.  Alerts are sent

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -1,9 +1,21 @@
-"""Render static HTML pages from lots using Jinja2."""
+"""Render static HTML pages from JSON lots using Jinja2.
 
+Each ``*.json`` file under ``data/lots`` may contain several lots so we assign
+a unique ``_page_id`` to every entry.  Templates live in ``templates/`` and the
+output is written to ``data/views`` keeping the directory layout intact.  The
+script also loads ``data/vectors.jsonl`` if present to find similar lots based
+on cosine similarity.  ``data/ontology.json`` is consulted to display table
+columns in a stable order.
+"""
+
+import json
+import math
 from pathlib import Path
+from datetime import datetime, timedelta
 
 from jinja2 import Environment, FileSystemLoader
 
+from config_utils import load_config
 from log_utils import get_logger, install_excepthook
 
 log = get_logger().bind(script=__file__)
@@ -12,22 +24,171 @@ install_excepthook(log)
 LOTS_DIR = Path("data/lots")
 VIEWS_DIR = Path("data/views")
 TEMPLATES = Path("templates")
+VEC_FILE = Path("data/vectors.jsonl")
+ONTOLOGY = Path("data/ontology.json")
 
 
-def build_page(env: Environment, lot_path: Path) -> None:
-    lot = lot_path.read_text()
+def _load_vectors() -> dict[str, list[float]]:
+    """Return mapping of lot id to embedding vector."""
+    if not VEC_FILE.exists():
+        log.info("Vector file missing", path=str(VEC_FILE))
+        return {}
+    data = {}
+    for line in VEC_FILE.read_text().splitlines():
+        try:
+            obj = json.loads(line)
+            data[obj["id"]] = obj["vec"]
+        except Exception:
+            log.exception("Failed to parse vector line", line=line)
+    log.info("Loaded vectors", count=len(data))
+    return data
+
+
+def _cos_sim(a: list[float], b: list[float]) -> float:
+    """Return cosine similarity between two vectors."""
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return -1.0
+    return dot / (na * nb)
+
+
+def _load_ontology() -> list[str]:
+    if not ONTOLOGY.exists():
+        return []
+    try:
+        data = json.loads(ONTOLOGY.read_text())
+    except Exception:
+        log.exception("Bad ontology", path=str(ONTOLOGY))
+        return []
+    return sorted(data.keys())
+
+
+def _iter_lots() -> list[dict]:
+    """Yield lots with helper metadata."""
+    lots = []
+    for path in LOTS_DIR.rglob("*.json"):
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            log.exception("Failed to parse lot file", file=str(path))
+            continue
+        if isinstance(data, dict):
+            data = [data]
+        base = path.stem
+        for i, lot in enumerate(data):
+            lot["_file"] = path
+            lot["_id"] = f"{base}-{i}"
+            lots.append(lot)
+    log.info("Loaded lots", count=len(lots))
+    return lots
+
+
+def build_page(env: Environment, lot: dict, similar: list[dict], fields: list[str], langs: list[str]) -> None:
+    images = []
+    for rel in lot.get("files", []):
+        p = Path("data/media") / rel
+        cap = p.with_suffix(".caption.md")
+        captions = {}
+        for lang in langs:
+            captions[lang] = cap.read_text(encoding="utf-8") if cap.exists() else ""
+        images.append({"path": rel, "caption": captions})
+
+    attrs = {k: v for k, v in lot.items() if k not in {"files"} and not k.startswith("title_") and not k.startswith("description_")}
+    sorted_attrs = {k: attrs[k] for k in fields if k in attrs}
+    for k in attrs:
+        if k not in sorted_attrs:
+            sorted_attrs[k] = attrs[k]
+
+    chat = lot.get("source:chat")
+    mid = lot.get("source:message_id")
+    tg_link = f"https://t.me/{chat}/{mid}" if chat and mid else ""
+
     template = env.get_template("lot.html")
-    out = VIEWS_DIR / (lot_path.stem + ".html")
-    out.write_text(template.render(lot=lot))
+    out = VIEWS_DIR / f"{lot['_id']}.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        template.render(
+            title=lot.get("title_en", "Lot"),
+            lot=lot,
+            images=images,
+            attrs=sorted_attrs,
+            tg_link=tg_link,
+            similar=similar,
+            langs=langs,
+        )
+    )
     log.debug("Wrote", path=str(out))
 
 
 def main() -> None:
     log.info("Building site")
     env = Environment(loader=FileSystemLoader(str(TEMPLATES)))
+    cfg = load_config()
+    langs = getattr(cfg, "LANGS", ["en"])
     VIEWS_DIR.mkdir(parents=True, exist_ok=True)
-    for p in LOTS_DIR.glob("*.json"):
-        build_page(env, p)
+
+    fields = _load_ontology()
+    vectors = _load_vectors()
+    lots = _iter_lots()
+
+    id_to_vec = {lot["_id"].split("-")[0]: vectors.get(lot["_id"].split("-")[0]) for lot in lots}
+
+    # Precompute similar lots
+    sim_map: dict[str, list[dict]] = {}
+    for lot in lots:
+        vec = id_to_vec.get(lot["_id"].split("-")[0])
+        if not vec:
+            sim_map[lot["_id"]] = []
+            continue
+        scores = []
+        for other in lots:
+            if other is lot:
+                continue
+            ov = id_to_vec.get(other["_id"].split("-")[0])
+            if not ov:
+                continue
+            scores.append((
+                _cos_sim(vec, ov),
+                other,
+            ))
+        scores.sort(key=lambda x: x[0], reverse=True)
+        items = []
+        for score, other in scores[:6]:
+            title = other.get("title_en") or next(
+                (other.get(f"title_{l}") for l in langs if other.get(f"title_{l}")),
+                other.get("_id"),
+            )
+            thumb = other.get("files", [""])[0]
+            items.append({
+                "link": f"{other['_id']}.html",
+                "title": title,
+                "thumb": thumb,
+            })
+        sim_map[lot["_id"]] = items
+
+    recent_cutoff = datetime.utcnow() - timedelta(days=7)
+    recent = []
+    for lot in lots:
+        ts = lot.get("timestamp")
+        try:
+            dt = datetime.fromisoformat(ts)
+        except Exception:
+            continue
+        if dt >= recent_cutoff:
+            title = lot.get("title_en") or next(
+                (lot.get(f"title_{l}") for l in langs if lot.get(f"title_{l}")),
+                lot.get("_id"),
+            )
+            recent.append({"link": f"{lot['_id']}.html", "title": title, "dt": dt})
+
+    for lot in lots:
+        build_page(env, lot, sim_map.get(lot["_id"], []), fields, langs)
+
+    recent.sort(key=lambda x: x["dt"], reverse=True)
+    index_tpl = env.get_template("index.html")
+    (VIEWS_DIR / "index.html").write_text(index_tpl.render(lots=recent, langs=langs, title="Index"))
     log.info("Site build complete")
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="static/style.css">
+    <script src="static/site.js" defer></script>
+</head>
+<body>
+<nav class="top">
+    <a href="index.html">Home</a>
+    <div class="lang-switch">
+    {% for l in langs %}
+        <button data-set-lang="{{ l }}">{{ l }}</button>
+    {% endfor %}
+    </div>
+</nav>
+{{ body }}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block body %}
+<h1>Recent items</h1>
+<ul>
+{% for lot in lots %}
+  <li><a href="{{ lot.link }}">{{ lot.title }}</a></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/lot.html
+++ b/templates/lot.html
@@ -1,10 +1,29 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8" />
-    <title>Lot {{ lot }}</title>
-</head>
-<body>
-<pre>{{ lot }}</pre>
-</body>
-</html>
+{% extends 'base.html' %}
+{% block body %}
+<h1 class="lang" data-lang="{{ langs[0] }}">{{ lot['title_' + langs[0]] }}</h1>
+{% for lang in langs[1:] %}
+<h1 class="lang" data-lang="{{ lang }}">{{ lot['title_' + lang] }}</h1>
+{% endfor %}
+<div class="carousel">
+{% for img in images %}
+  <figure>
+    <img src="../{{ img.path }}" alt="" />
+    <figcaption class="lang" data-lang="{{ langs[0] }}">{{ img.caption[langs[0]] }}</figcaption>
+    {% for lang in langs[1:] %}
+    <figcaption class="lang" data-lang="{{ lang }}">{{ img.caption[lang] }}</figcaption>
+    {% endfor %}
+  </figure>
+{% endfor %}
+</div>
+<table class="attrs">
+{% for key, val in attrs.items() %}
+  <tr><th>{{ key }}</th><td>{{ val }}</td></tr>
+{% endfor %}
+</table>
+<p><a href="{{ tg_link }}">Telegram post</a></p>
+<div class="similar">
+{% for item in similar %}
+  <a href="{{ item.link }}"><img src="../{{ item.thumb }}" alt="" /><br>{{ item.title }}</a>
+{% endfor %}
+</div>
+{% endblock %}

--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -1,0 +1,14 @@
+function switchLang(lang) {
+  document.querySelectorAll('.lang').forEach(el => {
+    el.classList.toggle('active', el.dataset.lang === lang);
+  });
+  localStorage.setItem('lang', lang);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = localStorage.getItem('lang');
+  if (saved) switchLang(saved);
+  document.querySelectorAll('[data-set-lang]').forEach(btn => {
+    btn.addEventListener('click', () => switchLang(btn.dataset.setLang));
+  });
+});

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -1,0 +1,12 @@
+body { font-family: sans-serif; margin: 0; padding: 1em; }
+nav.top { display: flex; justify-content: space-between; margin-bottom: 1em; }
+.lang-switch button { margin-left: 0.5em; }
+.lang { display: none; }
+.lang.active { display: block; }
+.carousel { display: flex; gap: 0.5em; overflow-x: auto; }
+.carousel img { max-height: 200px; }
+table.attrs { border-collapse: collapse; margin-top: 1em; }
+table.attrs td, table.attrs th { border: 1px solid #ddd; padding: 0.25em 0.5em; }
+.similar { display: flex; flex-wrap: wrap; gap: 0.5em; margin-top: 1em; }
+.similar a { text-decoration: none; border: 1px solid #ddd; padding: 0.25em; }
+.similar img { max-height: 80px; display: block; }

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import json
+import sys
+import os
+
+os.environ.setdefault("LOG_LEVEL", "INFO")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import build_site
+
+
+class DummyCfg:
+    LANGS = ["en"]
+
+
+def test_build_site_creates_pages(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "VEC_FILE", tmp_path / "vec.jsonl")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": "2024-05-20T00:00:00",
+            "title_en": "hello",
+            "files": []
+        }
+    ]))
+
+    build_site.main()
+
+    assert (tmp_path / "views" / "1-0.html").exists()
+    assert (tmp_path / "views" / "index.html").exists()


### PR DESCRIPTION
## Summary
- redesign build_site.py to render individual lot pages
- add base template, index page and JS/CSS assets
- show captions, telegram links and similar items
- document new build_site behaviour
- include regression test for build_site

## Testing
- `pytest -q`
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68558a21801c8324876c64ccc1bbb5ee