### PR TITLE
Fix embed.py scanning nested lots

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -76,7 +76,9 @@ plain JSON without Markdown wrappers.
 
 ## embed.py
 Generates `text-embedding-3-large` vectors for each lot.  Vectors are stored both in
-`data/vectors.jsonl` and in the `lot_vec` table using pgvector.
+`data/vectors.jsonl` and in the `lot_vec` table using pgvector. The script
+recursively scans `data/lots` for `*.json` files, matching the nested layout
+produced by `chop.py`.
 
 Translations are now produced by `chop.py` itself.  Fields like
 `title_ru` or `description_ka` are included in the lot JSON directly. Titles

--- a/src/embed.py
+++ b/src/embed.py
@@ -22,6 +22,9 @@ install_excepthook(log)
 
 openai.api_key = OPENAI_KEY
 
+# ``chop.py`` mirrors the directory layout of the source messages so lot files
+# can be nested several levels deep. ``rglob`` is used to scan everything under
+# the root ``data/lots`` directory.
 LOTS_DIR = Path("data/lots")
 VEC_FILE = Path("data/vectors.jsonl")
 
@@ -59,10 +62,12 @@ def embed_text(lot_id: str, text: str, cur) -> None:
 def main() -> None:
     log.info("Embedding lots")
     log.debug("Connecting to Postgres")
+    lot_paths = list(LOTS_DIR.rglob("*.json"))
+    log.info("Found lot files", count=len(lot_paths))
     with psycopg2.connect(DB_DSN) as conn:
         with conn.cursor() as cur:
             cur.execute(CREATE_SQL)
-            for path in LOTS_DIR.glob("*.json"):
+            for path in lot_paths:
                 lot_id = path.stem
                 text = path.read_text()
                 embed_text(lot_id, text, cur)


### PR DESCRIPTION
## Summary
- ensure `embed.py` scans `data/lots` recursively
- log how many lot files were found
- document recursive scanning in `services.md`

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558e0e358c83249352445afc6d4abd