### PR TITLE
Update embedding storage layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,10 @@ chop: pull
 	$(PYTHON) scripts/pending_chop.py \
 	| parallel -0 $(PYTHON) src/chop.py
 
-# Store embeddings for each lot in Postgres and JSONL.
+# Store embeddings for each lot in JSON files using GNU Parallel.
 embed: chop
-	$(PYTHON) src/embed.py
+	$(PYTHON) scripts/pending_embed.py \
+	| parallel -0 $(PYTHON) src/embed.py
 
 # Render HTML pages from lots and templates.
 build: embed

--- a/config.example.py
+++ b/config.example.py
@@ -23,9 +23,6 @@ CHATS = ["baraholka_ge", "baraholka_avito_batumi"]
 # OpenAI API key used for captioning, chopping and translating.
 OPENAI_KEY = "sk-..."
 
-# PostgreSQL DSN where the embedding vectors are stored.  The ``lot_vec`` table
-# is expected to use the ``pgvector`` extension.
-DB_DSN = "postgresql:///bazaar"
 
 # Languages used when parsing lots.  ``chop.py`` will generate title and
 # description fields for each entry in this list.

--- a/docs/services.md
+++ b/docs/services.md
@@ -75,10 +75,9 @@ processed at once. The API call specifies `response_format={"type":
 "json_object"}` so GPT-4o returns plain JSON without Markdown wrappers.
 
 ## embed.py
-Generates `text-embedding-3-large` vectors for each lot.  Vectors are stored both in
-`data/vectors.jsonl` and in the `lot_vec` table using pgvector. The script
-recursively scans `data/lots` for `*.json` files, matching the nested layout
-produced by `chop.py`.
+Generates `text-embedding-3-large` vectors for each message file.  The output is
+stored under `data/vectors/` mirroring the layout of `data/lots`.  GNU Parallel
+processes the newest files first so search results are quickly refreshed.
 
 Translations are now produced by `chop.py` itself.  Fields like
 `title_ru` or `description_ka` are included in the lot JSON directly. Titles
@@ -88,7 +87,7 @@ applicable so that every language has a meaningful summary.
 ## build_site.py
 Renders the static marketplace website using Jinja templates.  Lots are read
 from `data/lots` and written to `data/views`.  The script loads
-`ontology.json` to order attribute tables and `vectors.jsonl` to suggest
+`ontology.json` to order attribute tables and embeddings from `data/vectors` to suggest
 similar lots.  Each lot page shows images in a small carousel, a table of
 all recognised fields and a link back to the Telegram post.  Pages are
 generated in all languages listed in `config.py` with a simple JavaScript

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,7 +6,7 @@ modules are available as packages:
 ```bash
 sudo apt install python3-openai \
     python3-python-telegram-bot \
-    python3-psycopg2 python3-jinja2 \
+    python3-jinja2 \
     python3-structlog python3-telethon
 ```
 
@@ -33,7 +33,6 @@ variables before running any script:
 - `CHATS` – list of chat or channel usernames to mirror.  The client will join
   them automatically if needed.
 - `OPENAI_KEY` – API key for OpenAI models
-- `DB_DSN` – PostgreSQL DSN used by embedding storage
 
 Use the Makefile in the repository root to run the pipeline:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 openai
 python-telegram-bot
-psycopg2-binary
 jinja2
 structlog
 telethon

--- a/scripts/pending_embed.py
+++ b/scripts/pending_embed.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""List lot JSON files needing embeddings."""
+from pathlib import Path
+import sys
+
+LOTS_DIR = Path("data/lots")
+VEC_DIR = Path("data/vectors")
+
+
+def main() -> None:
+    files = sorted(LOTS_DIR.rglob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for path in files:
+        rel = path.relative_to(LOTS_DIR)
+        out = (VEC_DIR / rel).with_suffix(".json")
+        if not out.exists() or out.stat().st_mtime < path.stat().st_mtime:
+            sys.stdout.write(str(path))
+            sys.stdout.write("\0")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -18,7 +18,7 @@ def test_build_site_creates_pages(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_FILE", tmp_path / "vec.jsonl")
+    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+import types
+import json
+
+# stub openai
+dummy_openai = types.ModuleType("openai")
+class DummyEmbeddings:
+    @staticmethod
+    def create(*a, **k):
+        return types.SimpleNamespace(data=[types.SimpleNamespace(embedding=[1,2,3])])
+
+dummy_openai.embeddings = DummyEmbeddings()
+sys.modules["openai"] = dummy_openai
+
+# config stub
+dummy_cfg = types.ModuleType("config")
+dummy_cfg.OPENAI_KEY = ""
+sys.modules["config"] = dummy_cfg
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import embed
+
+
+def test_embed_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(embed, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(embed, "VEC_DIR", tmp_path / "vecs")
+
+    path = tmp_path / "lots" / "chat" / "2024" / "05" / "1.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("text")
+
+    embed.main([str(path)])
+
+    out = tmp_path / "vecs" / "chat" / "2024" / "05" / "1.json"
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["id"] == "chat/1"
+    assert data["vec"] == [1,2,3]


### PR DESCRIPTION
## Summary
- store embeddings in hierarchical JSON files
- process them with GNU Parallel via a new `pending_embed.py` helper
- drop Postgres usage and related config
- update build site logic to load embeddings from directory
- document the new process and update setup instructions
- add tests for the new embed script

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855937fceac8324846ad926ab8cbb06