### PR TITLE
Render site pages per language with sortable index

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -91,8 +91,10 @@ from `data/lots` and written to `data/views`.  The script loads
 similar lots.  Similarity search now uses `scikit-learn` to find nearest
 neighbours efficiently. Each lot page shows images in a small carousel, a table of
 all recognised fields and a link back to the Telegram post.  Pages are
-generated in all languages listed in `config.py` with a simple JavaScript
-switcher.  An index page lists items from the last week grouped by day.
+generated separately for every language configured in `config.py`.  The
+navigation bar links to the same page in other languages instead of toggling via
+JavaScript.  The index page shows a sortable table listing items from the last
+week together with posting time, price and seller details.
 
 ## alert_bot.py
 Simple Telegram bot that lets users subscribe to notifications.  Alerts are sent

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,10 +8,14 @@
 </head>
 <body>
 <nav class="top">
-    <a href="index.html">Home</a>
+    <a href="{{ home_link }}">Home</a>
     <div class="lang-switch">
     {% for l in langs %}
-        <button data-set-lang="{{ l }}">{{ l }}</button>
+        {% if l == current_lang %}
+        <span class="current-lang">{{ l }}</span>
+        {% else %}
+        <a data-set-lang="{{ l }}" href="{{ page_basename }}_{{ l }}.html">{{ l }}</a>
+        {% endif %}
     {% endfor %}
     </div>
 </nav>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,24 @@
 {% extends 'base.html' %}
 {% block body %}
 <h1>Recent items</h1>
-{% for day, items in groups %}
-<h2>{{ day }}</h2>
-<ul>
+<table id="index-table">
+  <thead>
+    <tr>
+      <th data-sort="string">Title</th>
+      <th data-sort="number">Price</th>
+      <th data-sort="string">Seller</th>
+      <th data-sort="time">Time</th>
+    </tr>
+  </thead>
+  <tbody>
   {% for lot in items %}
-  <li><a href="{{ lot.link }}">{{ lot.title }}</a></li>
+    <tr>
+      <td><a href="{{ lot.link }}">{{ lot.title }}</a></td>
+      <td>{{ lot.price }}</td>
+      <td>{{ lot.seller }}</td>
+      <td data-raw="{{ lot.dt.isoformat() }}">{{ lot.dt.strftime('%Y-%m-%d %H:%M') }}</td>
+    </tr>
   {% endfor %}
-</ul>
-{% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/templates/lot.html
+++ b/templates/lot.html
@@ -1,17 +1,11 @@
 {% extends 'base.html' %}
 {% block body %}
-<h1 class="lang" data-lang="{{ langs[0] }}">{{ lot['title_' + langs[0]] }}</h1>
-{% for lang in langs[1:] %}
-<h1 class="lang" data-lang="{{ lang }}">{{ lot['title_' + lang] }}</h1>
-{% endfor %}
+<h1>{{ lot['title_' + current_lang] }}</h1>
 <div class="carousel">
 {% for img in images %}
   <figure>
-    <img src="../{{ img.path }}" alt="" />
-    <figcaption class="lang" data-lang="{{ langs[0] }}">{{ img.caption[langs[0]] }}</figcaption>
-    {% for lang in langs[1:] %}
-    <figcaption class="lang" data-lang="{{ lang }}">{{ img.caption[lang] }}</figcaption>
-    {% endfor %}
+    <img src="../media/{{ img.path }}" alt="" />
+    <figcaption>{{ img.caption }}</figcaption>
   </figure>
 {% endfor %}
 </div>
@@ -20,10 +14,10 @@
   <tr><th>{{ key }}</th><td>{{ val }}</td></tr>
 {% endfor %}
 </table>
-<p><a href="{{ tg_link }}">Telegram post</a></p>
+<p><a href="{{ tg_link }}" target="_blank">Telegram post</a></p>
 <div class="similar">
 {% for item in similar %}
-  <a href="{{ item.link }}"><img src="../{{ item.thumb }}" alt="" /><br>{{ item.title }}</a>
+  <a href="{{ item.link }}"><img src="../media/{{ item.thumb }}" alt="" /><br>{{ item.title }}</a>
 {% endfor %}
 </div>
 {% endblock %}

--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -1,14 +1,34 @@
-function switchLang(lang) {
-  document.querySelectorAll('.lang').forEach(el => {
-    el.classList.toggle('active', el.dataset.lang === lang);
-  });
-  localStorage.setItem('lang', lang);
-}
-
 document.addEventListener('DOMContentLoaded', () => {
-  const saved = localStorage.getItem('lang');
-  if (saved) switchLang(saved);
-  document.querySelectorAll('[data-set-lang]').forEach(btn => {
-    btn.addEventListener('click', () => switchLang(btn.dataset.setLang));
+  document.querySelectorAll('[data-set-lang]').forEach(a => {
+    a.addEventListener('click', () => {
+      localStorage.setItem('lang', a.dataset.setLang);
+    });
+  });
+
+  document.querySelectorAll('th[data-sort]').forEach(th => {
+    th.addEventListener('click', () => {
+      const table = th.closest('table');
+      const idx = Array.from(th.parentNode.children).indexOf(th);
+      const tbody = table.querySelector('tbody');
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      const asc = !th.classList.contains('asc');
+      const type = th.dataset.sort;
+      rows.sort((a, b) => {
+        let A = a.cells[idx].dataset.raw || a.cells[idx].textContent;
+        let B = b.cells[idx].dataset.raw || b.cells[idx].textContent;
+        if (type === 'number') {
+          A = parseFloat(A) || 0;
+          B = parseFloat(B) || 0;
+        } else if (type === 'time') {
+          A = Date.parse(A);
+          B = Date.parse(B);
+        }
+        return (A > B ? 1 : (A < B ? -1 : 0)) * (asc ? 1 : -1);
+      });
+      tbody.innerHTML = '';
+      rows.forEach(r => tbody.appendChild(r));
+      table.querySelectorAll('th').forEach(h => h.classList.remove('asc', 'desc'));
+      th.classList.add(asc ? 'asc' : 'desc');
+    });
   });
 });

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -1,8 +1,6 @@
 body { font-family: sans-serif; margin: 0; padding: 1em; }
 nav.top { display: flex; justify-content: space-between; margin-bottom: 1em; }
-.lang-switch button { margin-left: 0.5em; }
-.lang { display: none; }
-.lang.active { display: block; }
+.lang-switch a { margin-left: 0.5em; }
 .carousel { display: flex; gap: 0.5em; overflow-x: auto; }
 .carousel img { max-height: 200px; }
 table.attrs { border-collapse: collapse; margin-top: 1em; }
@@ -10,3 +8,6 @@ table.attrs td, table.attrs th { border: 1px solid #ddd; padding: 0.25em 0.5em; 
 .similar { display: flex; flex-wrap: wrap; gap: 0.5em; margin-top: 1em; }
 .similar a { text-decoration: none; border: 1px solid #ddd; padding: 0.25em; }
 .similar img { max-height: 80px; display: block; }
+table#index-table { border-collapse: collapse; width: 100%; }
+table#index-table th, table#index-table td { border: 1px solid #ddd; padding: 0.25em 0.5em; }
+table#index-table th { cursor: pointer; }

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -36,10 +36,9 @@ def test_build_site_creates_pages(tmp_path, monkeypatch):
 
     build_site.main()
 
-    assert (tmp_path / "views" / "1-0.html").exists()
-    index = tmp_path / "views" / "index.html"
+    assert (tmp_path / "views" / "1-0_en.html").exists()
+    index = tmp_path / "views" / "index_en.html"
     assert index.exists()
     idx_html = index.read_text()
-    day = now.split("T")[0]
-    assert f"<h2>{day}</h2>" in idx_html
-    assert "1-0.html" in idx_html
+    assert "hello" in idx_html
+    assert "1-0_en.html" in idx_html


### PR DESCRIPTION
## Summary
- build every lot page and index per language
- link languages via navigation switcher
- show posting time, price and seller in index table
- fix image paths and Telegram link behavior
- update docs and tests for new output

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855af3a869083248b1900fa14e0b6d5