### PR TITLE
Handle post author and future timestamps

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -37,7 +37,7 @@ Metadata fields include at least:
 
 - `id`, `chat`, `date`, `reply_to`, `is_admin`
 - `sender` (numeric), `sender_name`, `sender_username`, `sender_phone`,
-  `tg_link`
+  `post_author`, `tg_link`
 - `group_id` if part of an album
 - `files` – list of stored media paths
 
@@ -94,7 +94,9 @@ all recognised fields and a link back to the Telegram post.  Pages are
 generated separately for every language configured in `config.py`.  The
 navigation bar links to the same page in other languages instead of toggling via
 JavaScript.  The index page shows a sortable table listing items from the last
-week together with posting time, price and seller details.
+week together with posting time, price and seller details.  If a lot has a
+timestamp that lies in the future it is ignored during rendering so the website
+never displays misleading dates.
 
 ## alert_bot.py
 Simple Telegram bot that lets users subscribe to notifications.  Alerts are sent

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -143,6 +143,19 @@ def build_page(env: Environment, lot: dict, similar: list[dict], fields: list[st
             if k not in sorted_attrs:
                 sorted_attrs[k] = attrs[k]
 
+        ts = sorted_attrs.get("timestamp")
+        if ts:
+            try:
+                dt = datetime.fromisoformat(ts)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                if dt > datetime.now(timezone.utc):
+                    del sorted_attrs["timestamp"]
+                    log.debug("Dropped future timestamp", id=lot.get("_id"))
+            except Exception:
+                del sorted_attrs["timestamp"]
+                log.debug("Bad timestamp", id=lot.get("_id"), value=ts)
+
         # Show the original message text for context if available.
         orig_text = ""
         src = lot.get("source:path")
@@ -250,19 +263,25 @@ def main() -> None:
 
     # ``datetime.utcnow`` returns a naive object which breaks comparisons with
     # timezone-aware timestamps coming from lots.  Normalize everything to UTC.
-    recent_cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    now = datetime.now(timezone.utc)
+    recent_cutoff = now - timedelta(days=7)
     recent = []
     for lot in lots:
         ts = lot.get("timestamp")
-        try:
-            dt = datetime.fromisoformat(ts)
-            if dt.tzinfo is None:
-                # Older data might have naive timestamps. Assume UTC for
-                # backwards compatibility so comparisons work.
-                dt = dt.replace(tzinfo=timezone.utc)
-        except Exception:
-            continue
-        if dt >= recent_cutoff:
+        dt = None
+        if ts:
+            try:
+                dt = datetime.fromisoformat(ts)
+                if dt.tzinfo is None:
+                    # Older data might have naive timestamps. Assume UTC for
+                    # backwards compatibility so comparisons work.
+                    dt = dt.replace(tzinfo=timezone.utc)
+                if dt > now:
+                    log.debug("Ignoring future timestamp", id=lot.get("_id"))
+                    dt = None
+            except Exception:
+                dt = None
+        if dt and dt >= recent_cutoff:
             titles = {lang: lot.get(f"title_{lang}") for lang in langs}
             seller = (
                 lot.get("contact:phone")
@@ -286,7 +305,7 @@ def main() -> None:
         log.debug("Rendering", id=lot["_id"])
         build_page(env, lot, sim_map.get(lot["_id"], []), fields, langs)
 
-    recent.sort(key=lambda x: x["dt"], reverse=True)
+    recent.sort(key=lambda x: x.get("dt") or now, reverse=True)
 
     log.debug("Writing index pages")
     index_tpl = env.get_template("index.html")

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -250,13 +250,19 @@ async def _save_message(client: TelegramClient, chat: str, msg: Message) -> None
         log.debug("Failed to fetch permissions", chat=chat, user=msg.sender_id)
 
     sender = await msg.get_sender()
+    post_author = getattr(msg, "post_author", None)
+    sender_name = " ".join(
+        p for p in [getattr(sender, "first_name", None), getattr(sender, "last_name", None)] if p
+    ) or None
+    if not sender_name:
+        sender_name = post_author
+
     meta = {
         "id": msg.id,
         "chat": chat,
         "sender": msg.sender_id,
-        "sender_name": " ".join(
-            p for p in [getattr(sender, "first_name", None), getattr(sender, "last_name", None)] if p
-        ) or None,
+        "sender_name": sender_name,
+        "post_author": post_author,
         "sender_username": getattr(sender, "username", None),
         "sender_phone": format_georgian(getattr(sender, "phone", "") or ""),
         "tg_link": f"https://t.me/{sender.username}" if getattr(sender, "username", None) else None,

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
       <td><a href="{{ lot.link }}">{{ lot.title }}</a></td>
       <td>{{ lot.price or '' }}</td>
       <td>{{ lot.seller or '' }}</td>
-      <td data-raw="{{ lot.dt.isoformat() }}">{{ lot.dt.strftime('%Y-%m-%d %H:%M') }}</td>
+      <td{% if lot.dt %} data-raw="{{ lot.dt.isoformat() }}"{% endif %}>{{ lot.dt.strftime('%Y-%m-%d %H:%M') if lot.dt else '' }}</td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- store `post_author` in collected message metadata and use it to fill sender name
- document the new field and mention ignoring future timestamps in `build_site`
- drop timestamps that are in the future when building HTML
- allow index table to render lots without a timestamp

## Testing
- `pip install jinja2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b6838e588324b64601469578f518