### PR TITLE
Fix website static assets and image scaling

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -89,11 +89,13 @@ Renders the static marketplace website using Jinja templates.  Lots are read
 from `data/lots` and written to `data/views`.  The script loads
 `ontology.json` to order attribute tables and embeddings from `data/vectors` to suggest
 similar lots.  Similarity search now uses `scikit-learn` to find nearest
-neighbours efficiently. Each lot page shows images in a small carousel, a table of
+neighbours efficiently. Each lot page shows images in a small carousel,
+scaled to at most 40% of the viewport height, a table of
 all recognised fields and a link back to the Telegram post.  Pages are
 generated separately for every language configured in `config.py`.  The
 navigation bar links to the same page in other languages instead of toggling via
-JavaScript.  The index page shows a sortable table listing items from the last
+JavaScript.  Static files from `templates/static` are copied to
+`data/views/static` so the site works without extra assets. The index page shows a sortable table listing items from the last
 week together with posting time, price and seller details.
 
 ## alert_bot.py

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -11,6 +11,7 @@ columns in a stable order.
 import json
 import math
 from pathlib import Path
+import shutil
 from datetime import datetime, timedelta, timezone
 
 from jinja2 import Environment, FileSystemLoader
@@ -189,6 +190,15 @@ def main() -> None:
     cfg = load_config()
     langs = getattr(cfg, "LANGS", ["en"])
     VIEWS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Copy CSS and JS so the generated pages are standalone
+    static_src = TEMPLATES / "static"
+    static_dst = VIEWS_DIR / "static"
+    if static_src.exists():
+        if static_dst.exists():
+            shutil.rmtree(static_dst)
+        shutil.copytree(static_src, static_dst)
+        log.debug("Copied static assets", src=str(static_src), dst=str(static_dst))
 
     log.debug("Loading ontology")
     fields = _load_ontology()

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -2,7 +2,12 @@ body { font-family: sans-serif; margin: 0; padding: 1em; }
 nav.top { display: flex; justify-content: space-between; margin-bottom: 1em; }
 .lang-switch a { margin-left: 0.5em; }
 .carousel { display: flex; gap: 0.5em; overflow-x: auto; }
-.carousel.main img { cursor: pointer; max-height: 200px; }
+.carousel.main img {
+  cursor: pointer;
+  max-height: 40vh;
+  height: auto;
+  width: auto;
+}
 .carousel.similar img { max-height: 80px; }
 table.attrs { border-collapse: collapse; margin-top: 1em; }
 table.attrs td, table.attrs th { border: 1px solid #ddd; padding: 0.25em 0.5em; }

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -42,3 +42,5 @@ def test_build_site_creates_pages(tmp_path, monkeypatch):
     idx_html = index.read_text()
     assert "hello" in idx_html
     assert "1-0_en.html" in idx_html
+    assert (tmp_path / "views" / "static" / "site.js").exists()
+    assert (tmp_path / "views" / "static" / "style.css").exists()


### PR DESCRIPTION
## Summary
- copy JS/CSS assets to output when building site
- limit preview images to 40% of the viewport height
- document copied static files and new preview sizing
- test that build_site copies static assets

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b6d9d9c8832481f71739a84fa13c