### PR TITLE
Fix album captions and clean deleted posts

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -26,7 +26,8 @@ Uses Telethon to mirror the target chats as a normal user account.
   Media files live beside a `.md` description in
   `data/media/<chat>/<year>/<month>/`, named by their SHA-256 hash plus
   extension.  Albums are merged into a single file so every attachment appears
-  together.  Nothing is deleted; edits overwrite the Markdown in place.
+  together.  Messages that disappear from Telegram during the last week are
+  removed from disk while edits overwrite the Markdown in place.
 * **Resume state.** The timestamp of the last processed batch is stored under
   `data/state/<chat>.txt` so interrupted runs continue from the same point.
   Attachments that fail to download are skipped with a warning.  The client

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -295,7 +295,7 @@ def test_grouped_message(tmp_path, monkeypatch):
         cfg.CHATS = []
         monkeypatch.setitem(sys.modules, "config", cfg)
 
-        tg_client = importlib.import_module("tg_client")
+        tg_client = importlib.reload(importlib.import_module("tg_client"))
 
         monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path)
         monkeypatch.setattr(tg_client, "MEDIA_DIR", tmp_path / "media")
@@ -313,6 +313,70 @@ def test_grouped_message(tmp_path, monkeypatch):
         files = list(chat_dir.glob("*.md"))
         assert len(files) == 1
         assert "files" in files[0].read_text()
+
+    asyncio.run(run())
+
+
+def test_grouped_message_resume(tmp_path, monkeypatch):
+    async def run():
+        cfg = types.ModuleType("config")
+        cfg.TG_API_ID = 0
+        cfg.TG_API_HASH = ""
+        cfg.TG_SESSION = ""
+        cfg.CHATS = []
+        monkeypatch.setitem(sys.modules, "config", cfg)
+
+        tg_client = importlib.reload(importlib.import_module("tg_client"))
+
+        monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path)
+        monkeypatch.setattr(tg_client, "MEDIA_DIR", tmp_path / "media")
+
+        client = types.SimpleNamespace(get_permissions=fake_get_permissions)
+
+        date = datetime.datetime(2024, 5, 1)
+        msg1 = DummyMessage(1, date, grouped_id=11, media=True)
+        msg2 = DummyMessage(2, date, grouped_id=11, text="caption", media=True)
+
+        await tg_client._save_message(client, "chat", msg1)
+        tg_client._GROUPS.clear()
+        await tg_client._save_message(client, "chat", msg2)
+
+        chat_dir = tmp_path / "chat" / "2024" / "05"
+        files = list(chat_dir.glob("*.md"))
+        assert len(files) == 1
+        text = files[0].read_text()
+        assert "id: 2" in text
+
+    asyncio.run(run())
+
+
+def test_remove_deleted_recent(tmp_path, monkeypatch):
+    async def run():
+        cfg = types.ModuleType("config")
+        cfg.TG_API_ID = 0
+        cfg.TG_API_HASH = ""
+        cfg.TG_SESSION = ""
+        cfg.CHATS = ["chat"]
+        monkeypatch.setitem(sys.modules, "config", cfg)
+
+        tg_client = importlib.reload(importlib.import_module("tg_client"))
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        monkeypatch.setattr(tg_client, "RAW_DIR", tmp_path)
+        monkeypatch.setattr(tg_client, "MEDIA_DIR", tmp_path / "media")
+
+        msg_dir = tmp_path / "chat" / f"{now:%Y}" / f"{now:%m}"
+        msg_dir.mkdir(parents=True)
+        md = msg_dir / "1.md"
+        md.write_text(f"id: 1\ndate: {now.isoformat()}\n\n")
+
+        class DummyClient:
+            async def get_messages(self, chat, ids):
+                return None
+
+        await tg_client.remove_deleted(DummyClient())
+
+        assert not md.exists()
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- keep Telegram album captions when the client restarts
- remove locally stored posts deleted on Telegram within a week
- document how deletions are handled
- add tests for album resume and deletion cleanup

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c5d95a908324a7233330f0de54af