### PR TITLE
Add log level config and tidy clean_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ For installation instructions see [docs/setup.md](docs/setup.md).
 The project goals are described in [docs/vision.md](docs/vision.md).
 Approximate OpenAI expenses are outlined in [docs/costs.md](docs/costs.md).
 
-Logs are written to `errors.log` in JSON format. Set the `LOG_LEVEL`
-environment variable to `DEBUG`, `INFO` or `ERROR` to adjust verbosity. When
-`LOG_LEVEL` is `INFO`, `tg_client.py` logs each captioned file along with the
-generated text. Run `make caption` to (re)process any images that might have
-missed automatic captioning. Unicode characters, including Cyrillic, are stored
-verbatim so logs remain easy to read.
+Logs are written to `errors.log` in JSON format. Set `LOG_LEVEL` in
+`config.py` or as an environment variable to `DEBUG`, `INFO` or `ERROR` to
+adjust verbosity. When the level is `INFO`, `tg_client.py` logs each
+captioned file along with the generated text. Run `make caption` to
+(re)process any images that might have missed automatic captioning. Unicode
+characters, including Cyrillic, are stored verbatim so logs remain easy to
+read.

--- a/config.example.py
+++ b/config.example.py
@@ -31,4 +31,7 @@ LANGS = ["en", "ru", "ka"]
 # How many days of history to keep on disk
 KEEP_DAYS = 7
 
+# Default log verbosity. Use "DEBUG", "INFO" or "ERROR".
+LOG_LEVEL = "INFO"
+
 

--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -86,11 +86,28 @@ def _clean_lots() -> None:
         log.info("Removed stale lots", count=count)
 
 
+def _remove_empty_dirs(root: Path) -> None:
+    """Recursively remove empty folders under ``root``."""
+    count = 0
+    if not root.exists():
+        return
+    # walk bottom up so parent dirs are removed after their children
+    for path in sorted(root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if path.is_dir() and not any(path.iterdir()):
+            path.rmdir()
+            log.debug("Removed empty dir", path=str(path))
+            count += 1
+    if count:
+        log.info("Removed empty dirs", count=count)
+
+
 def main() -> None:
     cutoff = datetime.now(timezone.utc) - timedelta(days=KEEP_DAYS)
     _clean_raw(cutoff)
     _clean_media(cutoff)
     _clean_lots()
+    for root in [RAW_DIR, MEDIA_DIR, LOTS_DIR]:
+        _remove_empty_dirs(root)
 
 
 if __name__ == "__main__":

--- a/tests/test_clean_data.py
+++ b/tests/test_clean_data.py
@@ -31,6 +31,11 @@ def test_clean_data(tmp_path, monkeypatch):
     raw_new.parent.mkdir(parents=True, exist_ok=True)
     raw_new.write_text(f"id: 2\ndate: {recent.isoformat()}\n\nnew")
 
+    # directory that becomes empty after cleanup
+    raw_empty = clean_data.RAW_DIR / "oldchat" / "2024" / "05" / "1.md"
+    raw_empty.parent.mkdir(parents=True)
+    raw_empty.write_text(f"id: 3\ndate: {cutoff.isoformat()}\n\nold")
+
     media_dir = clean_data.MEDIA_DIR / "chat" / "2024" / "05"
     media_dir.mkdir(parents=True)
     img_old = media_dir / "a.jpg"
@@ -42,6 +47,12 @@ def test_clean_data(tmp_path, monkeypatch):
     (media_dir / "b.jpg.md").write_text(f"message_id:2\ndate:{recent.isoformat()}\n")
     (media_dir / "b.caption.md").write_text("cap")
 
+    media_empty_dir = clean_data.MEDIA_DIR / "oldchat" / "2024" / "05"
+    media_empty_dir.mkdir(parents=True)
+    img_old2 = media_empty_dir / "c.jpg"
+    img_old2.write_bytes(b"img")
+    (media_empty_dir / "c.jpg.md").write_text(f"message_id:3\ndate: {cutoff.isoformat()}\n")
+
     lot_dir = clean_data.LOTS_DIR / "chat" / "2024" / "05"
     lot_dir.mkdir(parents=True)
     old_lot = lot_dir / "1.json"
@@ -49,12 +60,20 @@ def test_clean_data(tmp_path, monkeypatch):
     new_lot = lot_dir / "2.json"
     new_lot.write_text(json.dumps([{"_id": "2", "source:path": "chat/2024/05/2.md"}]))
 
+    lot_empty_dir = clean_data.LOTS_DIR / "oldchat" / "2024" / "05"
+    lot_empty_dir.mkdir(parents=True)
+    empty_lot = lot_empty_dir / "3.json"
+    empty_lot.write_text(json.dumps([{"_id": "3", "source:path": "oldchat/2024/05/1.md"}]))
+
     clean_data.main()
 
     assert not raw_old.exists()
     assert raw_new.exists()
+    assert not raw_empty.parent.exists()
     assert not img_old.exists()
     assert not img_old.with_suffix(".md").exists()
     assert img_new.exists()
+    assert not media_empty_dir.exists()
     assert not old_lot.exists()
     assert new_lot.exists()
+    assert not lot_empty_dir.exists()


### PR DESCRIPTION
## Summary
- support LOG_LEVEL configuration with INFO default
- remove empty directories during `make clean`
- document LOG_LEVEL in README
- test new behaviour for `clean_data`

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855d0c493f8832499287b40e41d40c3