### PR TITLE
Fix unhashable fields in build_site

### DIFF
--- a/src/build_site.py
+++ b/src/build_site.py
@@ -306,8 +306,11 @@ def main() -> None:
     user_map: dict[str, list[dict]] = {}
     for lot in lots:
         user = lot.get("contact:telegram")
-        if user:
-            user_map.setdefault(user, []).append(lot)
+        if isinstance(user, list):
+            log.debug("Multiple telegram users", id=lot.get("_id"), value=user)
+            user = user[0] if user else None
+        if user is not None:
+            user_map.setdefault(str(user), []).append(lot)
 
     more_user_map: dict[str, list[dict]] = {}
     for user, user_lots in user_map.items():
@@ -356,11 +359,20 @@ def main() -> None:
             except Exception:
                 dt = None
         deal = lot.get("market:deal", "misc")
+        if not isinstance(deal, str):
+            log.debug("Non-string deal", id=lot.get("_id"), value=deal)
+            if isinstance(deal, list) and deal:
+                deal = deal[0]
+            else:
+                deal = str(deal)
         categories.setdefault(deal, []).append(lot)
         stat = category_stats.setdefault(deal, {"recent": 0, "users": set()})
         user = lot.get("contact:telegram")
+        if isinstance(user, list):
+            log.debug("Multiple telegram users", id=lot.get("_id"), value=user)
+            user = user[0] if user else None
         if user:
-            stat["users"].add(user)
+            stat["users"].add(str(user))
         if dt and dt >= recent_cutoff:
             titles = {lang: lot.get(f"title_{lang}") for lang in langs}
             seller = (

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -51,3 +51,30 @@ def test_build_site_creates_pages(tmp_path, monkeypatch):
     assert "1-0_en.html" in cat_html
     assert (tmp_path / "views" / "static" / "site.js").exists()
     assert (tmp_path / "views" / "static" / "style.css").exists()
+
+
+def test_handles_list_fields(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "hello",
+            "files": [],
+            "market:deal": ["sell_item", "other"],
+            "contact:telegram": ["@user", "@other"],
+        }
+    ]))
+
+    build_site.main()
+
+    assert (tmp_path / "views" / "1-0_en.html").exists()


### PR DESCRIPTION
## Summary
- handle list values for `contact:telegram` and `market:deal`
- log when lists are encountered
- add regression test for list field handling

## Testing
- `find src -name '*.py' -print0 | xargs -0 scripts/check_python.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685698a527a083248765463b658a5df7