### PR TITLE
Update ontology generation and tests

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -96,7 +96,7 @@ applicable so that every language has a meaningful summary.
 ## build_site.py
 Renders the static marketplace website using Jinja templates.  Lots are read
 from `data/lots` and written to `data/views`.  The script loads
-`ontology.json` to order attribute tables and embeddings from `data/vectors` to suggest
+`ontology/fields.json` to order attribute tables and embeddings from `data/vectors` to suggest
 similar lots.  Similarity search now uses `scikit-learn` to find nearest
 neighbours efficiently. Each lot page shows images in a small carousel,
 scaled to at most 40% of the viewport height, a table of
@@ -120,8 +120,8 @@ to all subscribers when new lots are detected.
 ## scan_ontology.py
 Walks through `data/lots` and collects a list of every key used across all
 stored lots.  For each key the script counts how many times each value appears
-and writes the result to `data/ontology.json`.  After collecting the counts the
-script removes a few noisy fields like timestamps and language specific
+and writes the result to `data/ontology/fields.json` along with helper files.
+After collecting the counts the script removes a few noisy fields like timestamps and language specific
 duplicates so the output focuses on meaningful attributes.  Run `make
 ontology` to generate the file for manual inspection.
 

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -4,7 +4,7 @@ Each ``*.json`` file under ``data/lots`` may contain several lots so we assign
 a unique ``_page_id`` to every entry.  Templates live in ``templates/`` and the
 output is written to ``data/views`` keeping the directory layout intact.  The
 script also loads ``data/vectors.jsonl`` if present to find similar lots based
-on cosine similarity.  ``data/ontology.json`` is consulted to display table
+on cosine similarity.  ``data/ontology/fields.json`` is consulted to display table
 columns in a stable order.
 """
 
@@ -33,7 +33,7 @@ LOTS_DIR = Path("data/lots")
 VIEWS_DIR = Path("data/views")
 TEMPLATES = Path("templates")
 VEC_DIR = Path("data/vectors")
-ONTOLOGY = Path("data/ontology.json")
+ONTOLOGY = Path("data/ontology/fields.json")
 RAW_DIR = Path("data/raw")
 
 

--- a/src/scan_ontology.py
+++ b/src/scan_ontology.py
@@ -1,4 +1,8 @@
-"""Scan lot JSONs and record unique keys with value counts."""
+"""Scan lot JSONs and record unique keys with value counts.
+
+The script also collects lots missing translated titles or descriptions
+and writes helper text files with all unique values for manual review.
+"""
 
 import json
 from collections import Counter, defaultdict
@@ -10,7 +14,25 @@ log = get_logger().bind(script=__file__)
 install_excepthook(log)
 
 LOTS_DIR = Path("data/lots")
-OUTPUT_FILE = Path("data/ontology.json")
+
+# All generated files live in ``data/ontology`` so the folder can be
+# inspected or removed without touching the raw lots.
+OUTPUT_DIR = Path("data/ontology")
+FIELDS_FILE = OUTPUT_DIR / "fields.json"
+MISSING_FILE = OUTPUT_DIR / "missing.json"
+
+REVIEW_FIELDS = [
+    "title_en",
+    "description_en",
+    "title_ru",
+    "description_ru",
+    "title_ka",
+    "description_ka",
+]
+
+# Mapping from field name to file path where unique values are stored for
+# manual review.
+REVIEW_FILES = {f: OUTPUT_DIR / f"{f}.txt" for f in REVIEW_FIELDS}
 
 # Fields that carry volatile per-message metadata or language specific
 # duplicates.  Dropping them keeps ``ontology.json`` focused on the
@@ -21,17 +43,18 @@ SKIP_FIELDS = {
     "source:path",
     "source:message_id",
     "source:chat",
-    "description_ka",
-    "title_ka",
-    "description_en",
-    "title_en",
     "files",
 }
 
+# Any key that starts with these prefixes is removed from the final counts.
+SKIP_PREFIXES = ("title_", "description_")
 
-def collect_ontology() -> dict[str, dict[str, int]]:
-    """Return dictionary mapping field names to value counts."""
+
+def collect_ontology() -> tuple[dict[str, dict[str, int]], list[dict], dict[str, set[str]]]:
+    """Return counts per field, lots missing translations and values."""
     ontology: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    missing: list[dict] = []
+    values: dict[str, set[str]] = {f: set() for f in REVIEW_FIELDS}
     for path in LOTS_DIR.rglob("*.json"):
         try:
             lots = json.loads(path.read_text())
@@ -43,6 +66,12 @@ def collect_ontology() -> dict[str, dict[str, int]]:
         for lot in lots:
             if not isinstance(lot, dict):
                 continue
+            if any(not lot.get(f) for f in REVIEW_FIELDS):
+                missing.append(lot)
+            for f in REVIEW_FIELDS:
+                val = lot.get(f)
+                if isinstance(val, str):
+                    values[f].add(val)
             for key, value in lot.items():
                 if isinstance(value, (dict, list)):
                     val = json.dumps(value, ensure_ascii=False, sort_keys=True)
@@ -53,20 +82,28 @@ def collect_ontology() -> dict[str, dict[str, int]]:
     result: dict[str, dict[str, int]] = {}
     for key, counter in ontology.items():
         result[key] = dict(sorted(counter.items(), key=lambda x: (-x[1], x[0])))
-    return result
+    return result, missing, values
 
 
 def main() -> None:
     log.info("Scanning ontology", path=str(LOTS_DIR))
-    data = collect_ontology()
-    removed = [f for f in SKIP_FIELDS if f in data]
+    data, missing, values = collect_ontology()
+    removed = [k for k in list(data) if k in SKIP_FIELDS or k.startswith(SKIP_PREFIXES)]
     for field in removed:
         data.pop(field, None)
     if removed:
         log.debug("Dropped fields", fields=removed)
-    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2))
-    log.info("Wrote ontology", path=str(OUTPUT_FILE))
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    FIELDS_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    log.info("Wrote field counts", path=str(FIELDS_FILE))
+
+    MISSING_FILE.write_text(json.dumps(missing, ensure_ascii=False, indent=2))
+    log.info("Wrote lots missing translations", path=str(MISSING_FILE))
+
+    for field, path in REVIEW_FILES.items():
+        path.write_text("\n".join(sorted(values[field])))
+        log.debug("Wrote values", field=field, path=str(path))
 
 
 if __name__ == "__main__":

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -9,7 +9,14 @@ import scan_ontology
 
 def test_collect_ontology(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "LOTS_DIR", tmp_path)
-    monkeypatch.setattr(scan_ontology, "OUTPUT_FILE", tmp_path / "out.json")
+    monkeypatch.setattr(scan_ontology, "OUTPUT_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "FIELDS_FILE", tmp_path / "fields.json")
+    monkeypatch.setattr(scan_ontology, "MISSING_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(
+        scan_ontology,
+        "REVIEW_FILES",
+        {f: tmp_path / f"{f}.txt" for f in scan_ontology.REVIEW_FIELDS},
+    )
 
     (tmp_path / "sub").mkdir()
     (tmp_path / "a.json").write_text(json.dumps([
@@ -20,7 +27,7 @@ def test_collect_ontology(tmp_path, monkeypatch):
 
     scan_ontology.main()
 
-    data = json.loads((tmp_path / "out.json").read_text())
+    data = json.loads((tmp_path / "fields.json").read_text())
     assert data["a"] == {"1": 1, "2": 1}
     assert data["b"] == {"x": 2, "y": 1}
     assert data["c"] == {"[1, 2]": 1}
@@ -28,7 +35,14 @@ def test_collect_ontology(tmp_path, monkeypatch):
 
 def test_skip_fields_are_removed(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "LOTS_DIR", tmp_path)
-    monkeypatch.setattr(scan_ontology, "OUTPUT_FILE", tmp_path / "out.json")
+    monkeypatch.setattr(scan_ontology, "OUTPUT_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "FIELDS_FILE", tmp_path / "fields.json")
+    monkeypatch.setattr(scan_ontology, "MISSING_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(
+        scan_ontology,
+        "REVIEW_FILES",
+        {f: tmp_path / f"{f}.txt" for f in scan_ontology.REVIEW_FIELDS},
+    )
 
     (tmp_path / "a.json").write_text(json.dumps({
         "timestamp": "now",
@@ -39,7 +53,7 @@ def test_skip_fields_are_removed(tmp_path, monkeypatch):
 
     scan_ontology.main()
 
-    data = json.loads((tmp_path / "out.json").read_text())
+    data = json.loads((tmp_path / "fields.json").read_text())
     assert "timestamp" not in data
     assert "contact:telegram" not in data
     assert "files" not in data


### PR DESCRIPTION
## Summary
- store ontology results in `data/ontology/`
- drop title and description fields from the counts
- record lots missing translation fields
- save unique title/description texts for review
- adjust build_site and docs
- update tests for new file layout

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569d6983b083248ae778583880d472