### PR TITLE
Add gettext translations and site cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Intermediate/
 session*
 config.py
 errors.log
+*.mo

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,4 @@ clean:
 
 precommit:
 	@find src -name '*.py' -print0 | xargs -0 scripts/check_python.sh
+	python scripts/check_translations.py

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ See [docs/services.md](docs/services.md) for an overview of the scripts.
 For installation instructions see [docs/setup.md](docs/setup.md).
 The project goals are described in [docs/vision.md](docs/vision.md).
 Approximate OpenAI expenses are outlined in [docs/costs.md](docs/costs.md).
+[Maintenance instructions](docs/maintenance.md) cover how to keep translations up to date.
 
 Logs are written to `errors.log` in JSON format. Set `LOG_LEVEL` in
 `config.py` or as an environment variable to `DEBUG`, `INFO` or `ERROR` to

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,4 @@
+# Maintenance
+
+Translations for website templates live under `locale/` as gettext `messages.po` files. Edit `locale/en/LC_MESSAGES/messages.po` to add new strings then update every other language.
+Run `make precommit` to compile the `.po` files and verify that all languages contain every string.

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "Categories"
+msgstr "Categories"
+
+msgid "Category"
+msgstr "Category"
+
+msgid "Posts last %(days)s days"
+msgstr "Posts last %(days)s days"
+
+msgid "Unique posters"
+msgstr "Unique posters"
+
+msgid "Title"
+msgstr "Title"
+
+msgid "Price"
+msgstr "Price"
+
+msgid "Seller"
+msgstr "Seller"
+
+msgid "Time"
+msgstr "Time"
+
+msgid "Original post"
+msgstr "Original post"
+
+msgid "More by this user"
+msgstr "More by this user"
+
+msgid "Telegram post"
+msgstr "Telegram post"
+
+msgid "Lot"
+msgstr "Lot"
+
+msgid "Index"
+msgstr "Index"

--- a/locale/ka/LC_MESSAGES/messages.po
+++ b/locale/ka/LC_MESSAGES/messages.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ka\n"
+
+msgid "Home"
+msgstr "მთავარი"
+
+msgid "Categories"
+msgstr "კატეგორიები"
+
+msgid "Category"
+msgstr "კატეგორია"
+
+msgid "Posts last %(days)s days"
+msgstr "პოსტები უკანასკნელი %(days)s დღის განმავლობაში"
+
+msgid "Unique posters"
+msgstr "უნიკალური მომხმარებლები"
+
+msgid "Title"
+msgstr "სათაური"
+
+msgid "Price"
+msgstr "ფასი"
+
+msgid "Seller"
+msgstr "გამყიდველი"
+
+msgid "Time"
+msgstr "დრო"
+
+msgid "Original post"
+msgstr "საწყისი პოსტი"
+
+msgid "More by this user"
+msgstr "მეტი ამ მომხმარებლისგან"
+
+msgid "Telegram post"
+msgstr "Telegram პოსტი"
+
+msgid "Lot"
+msgstr "ლოტი"
+
+msgid "Index"
+msgstr "მთავარი გვერდი"

--- a/locale/ru/LC_MESSAGES/messages.po
+++ b/locale/ru/LC_MESSAGES/messages.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: ru\n"
+
+msgid "Home"
+msgstr "Главная"
+
+msgid "Categories"
+msgstr "Категории"
+
+msgid "Category"
+msgstr "Категория"
+
+msgid "Posts last %(days)s days"
+msgstr "За последние %(days)s дней"
+
+msgid "Unique posters"
+msgstr "Уникальные авторы"
+
+msgid "Title"
+msgstr "Заголовок"
+
+msgid "Price"
+msgstr "Цена"
+
+msgid "Seller"
+msgstr "Продавец"
+
+msgid "Time"
+msgstr "Время"
+
+msgid "Original post"
+msgstr "Оригинальное сообщение"
+
+msgid "More by this user"
+msgstr "Другие объявления автора"
+
+msgid "Telegram post"
+msgstr "Сообщение в Telegram"
+
+msgid "Lot"
+msgstr "Лот"
+
+msgid "Index"
+msgstr "Главная страница"

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -1,0 +1,69 @@
+import subprocess
+import sys
+from pathlib import Path
+
+LOCALE_DIR = Path('locale')
+LANGS = ['en', 'ru', 'ka']
+
+
+def parse_po(path: Path) -> dict[str, str]:
+    msgs = {}
+    state = None
+    msgid = ''
+    msgstr = ''
+    with path.open(encoding='utf-8') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line.startswith('msgid '):
+                if state == 'msgstr':
+                    msgs[msgid] = msgstr
+                msgid = line[6:].strip().strip('"')
+                msgstr = ''
+                state = 'msgid'
+            elif line.startswith('msgstr '):
+                state = 'msgstr'
+                msgstr = line[7:].strip().strip('"')
+            elif line.startswith('"'):
+                text = line.strip().strip('"')
+                if state == 'msgid':
+                    msgid += text
+                elif state == 'msgstr':
+                    msgstr += text
+            elif not line.strip():
+                if state == 'msgstr':
+                    msgs[msgid] = msgstr
+                state = None
+                msgid = ''
+                msgstr = ''
+    if state == 'msgstr':
+        msgs[msgid] = msgstr
+    return msgs
+
+
+def check_translations() -> int:
+    base = LOCALE_DIR / 'en' / 'LC_MESSAGES' / 'messages.po'
+    base_msgs = parse_po(base)
+    success = True
+    for lang in LANGS:
+        po = LOCALE_DIR / lang / 'LC_MESSAGES' / 'messages.po'
+        if not po.exists():
+            print(f'Missing {po}', file=sys.stderr)
+            success = False
+            continue
+        msgs = parse_po(po)
+        for msgid in base_msgs:
+            if msgid not in msgs or not msgs[msgid].strip():
+                print(f'Missing translation for {msgid} in {lang}', file=sys.stderr)
+                success = False
+        # compile
+        mo = po.with_suffix('.mo')
+        try:
+            subprocess.run(['msgfmt', str(po), '-o', str(mo)], check=True)
+        except Exception:
+            print(f'Failed to compile {po}', file=sys.stderr)
+            success = False
+    return 0 if success else 1
+
+
+if __name__ == '__main__':
+    sys.exit(check_translations())

--- a/src/scan_ontology.py
+++ b/src/scan_ontology.py
@@ -78,6 +78,9 @@ def collect_ontology() -> tuple[
         for lot in lots:
             if not isinstance(lot, dict):
                 continue
+            for k in list(lot):
+                if lot[k] == "" or lot[k] is None:
+                    del lot[k]
             if any(not lot.get(f) for f in REVIEW_FIELDS):
                 missing.append(lot)
             if _is_misparsed(lot):

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,15 +8,24 @@
 </head>
 <body>
 <nav class="top">
-    <a href="{{ home_link }}">Home</a>
-    <div class="lang-switch">
-    {% for l in langs %}
-        {% if l == current_lang %}
-        <span class="current-lang">{{ l }}</span>
+    <span class="breadcrumbs">
+    {% for crumb in breadcrumbs %}
+        {% if loop.index > 1 %} &gt; {% endif %}
+        {% if crumb.link %}
+        <a href="{{ crumb.link }}">{{ _(crumb.title) }}</a>
         {% else %}
-        <a data-set-lang="{{ l }}" href="{{ page_basename }}_{{ l }}.html">{{ l }}</a>
+        <span>{{ _(crumb.title) }}</span>
         {% endif %}
     {% endfor %}
+    </span>
+    <div class="lang-switch">
+        {% for l in langs %}
+            {% if l == current_lang %}
+            <span class="current-lang">{{ l }}</span>
+            {% else %}
+            <a data-set-lang="{{ l }}" href="{{ page_basename }}_{{ l }}.html">{{ l }}</a>
+            {% endif %}
+        {% endfor %}
     </div>
 </nav>
 {% block body %}{% endblock %}

--- a/templates/category.html
+++ b/templates/category.html
@@ -4,10 +4,10 @@
 <table id="index-table">
   <thead>
     <tr>
-      <th data-sort="string">Title</th>
-      <th data-sort="number">Price</th>
-      <th data-sort="string">Seller</th>
-      <th data-sort="time">Time</th>
+      <th data-sort="string">{{ _('Title') }}</th>
+      <th data-sort="number">{{ _('Price') }}</th>
+      <th data-sort="string">{{ _('Seller') }}</th>
+      <th data-sort="time">{{ _('Time') }}</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% block body %}
-<h1>Categories</h1>
+<h1>{{ _('Categories') }}</h1>
 <table id="index-table">
   <thead>
     <tr>
-      <th data-sort="string">Category</th>
-      <th data-sort="number">Posts last {{ keep_days }} days</th>
-      <th data-sort="number">Unique posters</th>
+      <th data-sort="string">{{ _('Category') }}</th>
+      <th data-sort="number">{% trans days=keep_days %}Posts last {{ days }} days{% endtrans %}</th>
+      <th data-sort="number">{{ _('Unique posters') }}</th>
     </tr>
   </thead>
   <tbody>

--- a/templates/lot.html
+++ b/templates/lot.html
@@ -12,7 +12,7 @@
 
 <p class="description">{{ description }}</p>
 {% if orig_text %}
-<details class="orig-text"><summary>Original post</summary>
+<details class="orig-text"><summary>{{ _('Original post') }}</summary>
 <pre>{{ orig_text }}</pre>
 </details>
 {% endif %}
@@ -22,14 +22,14 @@
   <tr><th>{{ key }}</th><td>{{ val }}</td></tr>
 {% endfor %}
 </table>
-<p><a href="{{ tg_link }}" target="_blank">Telegram post</a></p>
+<p><a href="{{ tg_link }}" target="_blank">{{ _('Telegram post') }}</a></p>
 <div class="similar carousel">
 {% for item in similar %}
   <a href="{{ item.link }}"><img src="{{ media_prefix }}/{{ item.thumb }}" alt="" /><br>{{ item.title }}</a>
 {% endfor %}
 </div>
 {% if more_user %}
-<h2>More by this user</h2>
+<h2>{{ _('More by this user') }}</h2>
 <div class="more-user carousel">
 {% for item in more_user %}
   <a href="{{ item.link }}"><img src="{{ media_prefix }}/{{ item.thumb }}" alt="" /><br>{{ item.title }}</a>

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -66,3 +66,24 @@ def test_skip_fields_are_removed(tmp_path, monkeypatch):
 
     mis = json.loads((tmp_path / "misparsed.json").read_text())
     assert mis[0]["contact:telegram"] == "@username"
+
+
+def test_empty_values_dropped(tmp_path, monkeypatch):
+    monkeypatch.setattr(scan_ontology, "LOTS_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "OUTPUT_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "FIELDS_FILE", tmp_path / "fields.json")
+    monkeypatch.setattr(scan_ontology, "MISSING_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(scan_ontology, "MISPARSED_FILE", tmp_path / "misparsed.json")
+    monkeypatch.setattr(
+        scan_ontology,
+        "REVIEW_FILES",
+        {f: tmp_path / f"{f}.json" for f in scan_ontology.REVIEW_FIELDS},
+    )
+
+    (tmp_path / "a.json").write_text(json.dumps({"a": "", "b": None, "title_en": "x"}))
+
+    scan_ontology.main()
+
+    data = json.loads((tmp_path / "fields.json").read_text())
+    assert "a" not in data
+    assert "b" not in data


### PR DESCRIPTION
## Summary
- introduce gettext-based i18n with English, Russian and Georgian strings
- render breadcrumbs and use translated labels in templates
- copy referenced images into the site output
- drop empty values when scanning ontology and building pages
- add translation check script to `make precommit`
- document maintenance of translations

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856afc9ed708324b58c9e89bad3aa0b