### PR TITLE
Include parser input in misparsed lots

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -125,7 +125,8 @@ and writes the result to `data/ontology/fields.json`. Titles and descriptions
 are stored separately in JSON files with counts sorted by frequency. Any lot
 missing translated text is written to `missing.json` while obviously mis-parsed
 lots (for example those containing `contact:telegram` equal to `@username`)
-go into `misparsed.json`. After collecting the counts the script removes a few
+go into `misparsed.json`. Each entry now includes the exact text passed to the
+lot parser under the `input` key so issues can be reproduced. After collecting the counts the script removes a few
 noisy fields like timestamps and language specific duplicates so the output
 focuses on meaningful attributes. Run `make ontology` to generate the files for
 manual inspection.

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -1,0 +1,52 @@
+"""Utilities for handling raw message files."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from log_utils import get_logger
+from notes_utils import read_md
+
+log = get_logger().bind(module=__name__)
+
+
+def parse_md(path: Path) -> tuple[dict[str, str], str]:
+    """Return metadata dictionary and body text from ``path``."""
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    lines = text.splitlines()
+    meta: dict[str, str] = {}
+    body_start = 0
+    for i, line in enumerate(lines):
+        if not line.strip():
+            body_start = i + 1
+            break
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip()
+    body = "\n".join(lines[body_start:])
+    return meta, body
+
+
+def build_prompt(text: str, files: list[str], captions: list[str]) -> str:
+    """Return prompt combining message text with captioned file names."""
+    parts = []
+    if text.strip():
+        parts.append(f"Message text:\n{text.strip()}")
+    for file, caption in zip(files, captions):
+        parts.append(f"Image {file}:\n{caption.strip()}")
+    return "\n\n".join(parts)
+
+
+def gather_chop_input(msg_path: Path, media_dir: Path) -> str:
+    """Return the exact text fed to the lot parser for ``msg_path``."""
+    meta, text = parse_md(msg_path)
+    files = ast.literal_eval(meta.get("files", "[]")) if "files" in meta else []
+    captions = []
+    for rel in files:
+        cap_path = (media_dir / rel).with_suffix(".caption.md")
+        caption_text = read_md(str(cap_path))
+        captions.append(caption_text)
+    prompt = build_prompt(text, files, captions)
+    log.debug("Built parser input", path=str(msg_path))
+    return prompt

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+from pathlib import Path
 
 from log_utils import get_logger
+from message_utils import parse_md
 
 log = get_logger().bind(module=__name__)
 
@@ -19,23 +21,6 @@ BANNED_SUBSTRINGS = [
 RAW_DIR = Path("data/raw")
 LOTS_DIR = Path("data/lots")
 VEC_DIR = Path("data/vectors")
-
-
-def _parse_md(path: Path) -> tuple[dict, str]:
-    """Return metadata dictionary and body text from ``path``."""
-    text = path.read_text(encoding="utf-8") if path.exists() else ""
-    lines = text.splitlines()
-    meta: dict[str, str] = {}
-    body_start = 0
-    for i, line in enumerate(lines):
-        if not line.strip():
-            body_start = i + 1
-            break
-        if ":" in line:
-            k, v = line.split(":", 1)
-            meta[k.strip()] = v.strip()
-    body = "\n".join(lines[body_start:])
-    return meta, body
 
 
 def should_skip_text(text: str) -> bool:
@@ -77,7 +62,7 @@ def apply_to_history() -> None:
         raw = RAW_DIR / src if src else None
         if not raw or not raw.exists():
             continue
-        _, text = _parse_md(raw)
+        _, text = parse_md(raw)
         skip = should_skip_message(items[0], text) or any(
             should_skip_lot(l) for l in items
         )

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -16,6 +16,7 @@ sys.modules["config"] = dummy_cfg
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import chop
+from message_utils import build_prompt
 
 
 def test_chop_processes_nested(tmp_path, monkeypatch):
@@ -45,7 +46,7 @@ def test_build_prompt():
     msg = "hello"
     files = ["a.jpg", "b.jpg"]
     caps = ["cap a", "cap b"]
-    prompt = chop._build_prompt(msg, files, caps)
+    prompt = build_prompt(msg, files, caps)
     assert "Message text:" in prompt
     assert "Image a.jpg" in prompt
     assert "cap a" in prompt

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -13,6 +13,8 @@ def test_collect_ontology(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "FIELDS_FILE", tmp_path / "fields.json")
     monkeypatch.setattr(scan_ontology, "MISSING_FILE", tmp_path / "missing.json")
     monkeypatch.setattr(scan_ontology, "MISPARSED_FILE", tmp_path / "misparsed.json")
+    monkeypatch.setattr(scan_ontology, "RAW_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(
         scan_ontology,
         "REVIEW_FILES",
@@ -43,6 +45,8 @@ def test_skip_fields_are_removed(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "FIELDS_FILE", tmp_path / "fields.json")
     monkeypatch.setattr(scan_ontology, "MISSING_FILE", tmp_path / "missing.json")
     monkeypatch.setattr(scan_ontology, "MISPARSED_FILE", tmp_path / "misparsed.json")
+    monkeypatch.setattr(scan_ontology, "RAW_DIR", tmp_path)
+    monkeypatch.setattr(scan_ontology, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(
         scan_ontology,
         "REVIEW_FILES",
@@ -54,7 +58,9 @@ def test_skip_fields_are_removed(tmp_path, monkeypatch):
         "contact:telegram": "@username",
         "files": ["a.jpg"],
         "other": 5,
+        "source:path": "msg.md",
     }))
+    (tmp_path / "msg.md").write_text("id: 1\n\nhello", encoding="utf-8")
 
     scan_ontology.main()
 
@@ -65,7 +71,8 @@ def test_skip_fields_are_removed(tmp_path, monkeypatch):
     assert data["other"] == {"5": 1}
 
     mis = json.loads((tmp_path / "misparsed.json").read_text())
-    assert mis[0]["contact:telegram"] == "@username"
+    assert mis[0]["lot"]["contact:telegram"] == "@username"
+    assert "Message text:" in mis[0]["input"]
 
 
 def test_empty_values_dropped(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- introduce `message_utils` for shared parsing helpers
- use new helpers in all modules instead of local functions
- record parser input text in misparsed.json
- document new misparsed.json contents
- update tests

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b4109eb48324b7a296d3ee218f27