### PR TITLE
Skip lots missing translations

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -132,6 +132,8 @@ lot parser under the `input` key so issues can be reproduced. After collecting t
 noisy fields like timestamps and language specific duplicates so the output
 focuses on meaningful attributes. Run `make ontology` to generate the files for
 manual inspection.
+Lots flagged as misparsed are ignored by `build_site.py` so the website never
+shows incomplete posts.
 Any raw post lacking mandatory metadata is added to `broken_meta.json` so
 `tg_client.py` can refetch it during the next run.
 

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from log_utils import get_logger
 from message_utils import parse_md
+from scan_ontology import REVIEW_FIELDS
 
 log = get_logger().bind(module=__name__)
 
@@ -44,6 +45,9 @@ def should_skip_lot(lot: dict) -> bool:
     """Return ``True`` when the lot fails additional checks."""
     if lot.get("contact:telegram") == "@username":
         log.debug("Lot rejected", reason="example contact")
+        return True
+    if any(not lot.get(f) for f in REVIEW_FIELDS):
+        log.debug("Lot rejected", reason="missing translation", id=lot.get("_id"))
         return True
     return False
 

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -33,6 +33,11 @@ def test_build_site_creates_pages(tmp_path, monkeypatch):
         {
             "timestamp": now,
             "title_en": "hello",
+            "description_en": "d",
+            "title_ru": "hello",
+            "description_ru": "d",
+            "title_ka": "hello",
+            "description_ka": "d",
             "files": [],
             "market:deal": "sell_item",
             "contact:telegram": "@user",
@@ -73,6 +78,11 @@ def test_handles_list_fields(tmp_path, monkeypatch):
         {
             "timestamp": now,
             "title_en": "hello",
+            "description_en": "d",
+            "title_ru": "hello",
+            "description_ru": "d",
+            "title_ka": "hello",
+            "description_ka": "d",
             "files": [],
             "market:deal": ["sell_item", "other"],
             "contact:telegram": ["@user", "@other"],
@@ -102,6 +112,11 @@ def test_author_fallback(tmp_path, monkeypatch):
         {
             "timestamp": now,
             "title_en": "hello",
+            "description_en": "d",
+            "title_ru": "hello",
+            "description_ru": "d",
+            "title_ka": "hello",
+            "description_ka": "d",
             "files": [],
             "market:deal": "sell_item",
             "source:author:telegram": "@poster",
@@ -137,6 +152,11 @@ def test_build_site_skips_moderated(tmp_path, monkeypatch):
         {
             "timestamp": now,
             "title_en": "hello",
+            "description_en": "d",
+            "title_ru": "hello",
+            "description_ru": "d",
+            "title_ka": "hello",
+            "description_ka": "d",
             "files": [],
             "market:deal": "sell_item",
             "source:path": "1.md",
@@ -168,9 +188,42 @@ def test_build_site_skips_misparsed(tmp_path, monkeypatch):
         {
             "timestamp": now,
             "title_en": "bad",
+            "description_en": "d",
+            "title_ru": "bad",
+            "description_ru": "d",
+            "title_ka": "bad",
+            "description_ka": "d",
             "files": [],
             "market:deal": "sell_item",
             "contact:telegram": "@username",
+        }
+    ]))
+
+    build_site.main()
+
+    assert not (tmp_path / "views" / "1-0_en.html").exists()
+
+
+def test_build_site_skips_missing_titles(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "files": [],
+            "market:deal": "sell_item",
+            "contact:telegram": "@real"
         }
     ]))
 
@@ -200,6 +253,11 @@ def test_images_and_empty_values(tmp_path, monkeypatch):
         {
             "timestamp": now,
             "title_en": "x",
+            "description_en": "d",
+            "title_ru": "x",
+            "description_ru": "d",
+            "title_ka": "x",
+            "description_ka": "d",
             "files": ["a.jpg"],
             "market:deal": "sell_item",
             "extra": "",

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -15,4 +15,6 @@ def test_should_skip_text():
 def test_should_skip_lot():
     lot = {"contact:telegram": "@username"}
     assert moderation.should_skip_lot(lot)
-    assert not moderation.should_skip_lot({"contact:telegram": "@real"})
+    assert not moderation.should_skip_lot({"contact:telegram": "@real", "title_en": "x", "description_en": "d", "title_ru": "x", "description_ru": "d", "title_ka": "x", "description_ka": "d"})
+    incomplete = {"contact:telegram": "@real", "title_en": "x"}
+    assert moderation.should_skip_lot(incomplete)


### PR DESCRIPTION
## Summary
- skip lots missing translated titles/descriptions
- document that misparsed lots are ignored when building the site
- test build_site and moderation behaviour with new rule

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c6f0431c83248e9602e385a04929