### PR TITLE
Introduce typed IO helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ captioned file along with the generated text. Run `make caption` to
 (re)process any images that might have missed automatic captioning. Unicode
 characters, including Cyrillic, are stored verbatim so logs remain easy to
 read.
+
+Domain specific helpers like `src/post_io.py`, `src/lot_io.py` and
+`src/caption_io.py` provide validated loading and saving of posts,
+lots and captions.  They build on `src/serde_utils.py` so every stage
+creates directories automatically and logs parsing errors once.

--- a/docs/services.md
+++ b/docs/services.md
@@ -144,6 +144,12 @@ phrases. The checks also run inside `chop.py` and `build_site.py` so unwanted
 posts never reach the website. Update the library with new rules and rerun the
 script to clean past data.
 
+## File I/O helpers
+`post_io.py`, `lot_io.py`, `caption_io.py` and `image_io.py` handle posts,
+lots, captions and media metadata. They use `serde_utils.py` for the low-level
+JSON or Markdown handling so each script works with cleaned data and missing
+directories are created automatically.
+
 ## Makefile
 The `Makefile` in the repository root wires these scripts together.  Running
 `make compose` performs a full refresh: pulling messages (images are captioned on

--- a/src/caption.py
+++ b/src/caption.py
@@ -14,7 +14,7 @@ from config_utils import load_config
 cfg = load_config()
 OPENAI_KEY = cfg.OPENAI_KEY
 from log_utils import get_logger, install_excepthook
-from notes_utils import write_md
+from caption_io import write_caption
 from token_utils import estimate_tokens
 
 log = get_logger().bind(script=__file__)
@@ -112,7 +112,7 @@ def caption_file(path: Path) -> str:
         log.exception("Caption failed", sha=sha)
         return sha
 
-    write_md(out, text)
+    write_caption(out, text)
     log.info("Caption", file=str(path), text=text)
     return sha
 

--- a/src/caption_io.py
+++ b/src/caption_io.py
@@ -1,0 +1,20 @@
+"""Handle caption files stored beside images."""
+
+from pathlib import Path
+
+from serde_utils import read_md, write_md
+from log_utils import get_logger
+
+log = get_logger().bind(module=__name__)
+
+
+def read_caption(path: Path) -> str:
+    """Return caption text or empty string if missing."""
+    return read_md(path)
+
+
+def write_caption(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` with a trailing newline."""
+    write_md(path, text)
+    log.debug("Wrote caption", path=str(path))
+

--- a/src/chop.py
+++ b/src/chop.py
@@ -18,8 +18,9 @@ cfg = load_config()
 OPENAI_KEY = cfg.OPENAI_KEY
 LANGS = cfg.LANGS
 from log_utils import get_logger, install_excepthook
-from notes_utils import read_md
-from message_utils import parse_md, build_prompt
+from caption_io import read_caption
+from post_io import read_post
+from message_utils import build_prompt
 
 # Blueprint describing expected fields and message taxonomy used by the model.
 BLUEPRINT = Path("prompts/chopper_prompt.md").read_text(encoding="utf-8")
@@ -59,7 +60,7 @@ def process_message(msg_path: Path) -> None:
 
     log.info("Processing message", path=str(msg_path))
 
-    meta, text = parse_md(msg_path)
+    meta, text = read_post(msg_path)
     if should_skip_message(meta, text):
         log.info("Skipping message", path=str(msg_path), reason="moderation")
         return
@@ -75,7 +76,7 @@ def process_message(msg_path: Path) -> None:
             if not cap.exists():
                 log.info("Skipping message", path=str(msg_path), reason="missing-caption", file=str(p))
                 return
-            caption_text = read_md(cap)
+            caption_text = read_caption(cap)
             log.debug("Found caption", file=str(p), text=caption_text)
             captions.append(caption_text)
     # Combine the original message text with image captions. This ensures GPT

--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from config_utils import load_config
 from log_utils import get_logger, install_excepthook
+from lot_io import read_lots
 
 log = get_logger().bind(script=__file__)
 install_excepthook(log)
@@ -71,12 +72,10 @@ def _clean_lots() -> None:
     if not LOTS_DIR.exists():
         return
     for path in LOTS_DIR.rglob("*.json"):
-        try:
-            data = json.loads(path.read_text())
-        except Exception:
+        items = read_lots(path)
+        if not items:
             log.warning("Bad lot file", file=str(path))
             continue
-        items = data if isinstance(data, list) else [data]
         src = items[0].get("source:path")
         if src and not (RAW_DIR / src).exists():
             path.unlink()

--- a/src/embed.py
+++ b/src/embed.py
@@ -1,6 +1,5 @@
 """Generate embeddings for lots and store them as JSON files."""
 
-import json
 from pathlib import Path
 
 import argparse
@@ -13,6 +12,7 @@ cfg = load_config()
 OPENAI_KEY = cfg.OPENAI_KEY
 from log_utils import get_logger, install_excepthook
 from token_utils import estimate_tokens
+from serde_utils import write_json
 
 log = get_logger().bind(script=__file__)
 install_excepthook(log)
@@ -50,7 +50,7 @@ def embed_file(path: Path) -> None:
         log.exception("Embed failed", id=lot_id)
         return
 
-    out.write_text(json.dumps({"id": lot_id, "vec": vec}))
+    write_json(out, {"id": lot_id, "vec": vec})
     log.debug("Vector written", path=str(out))
 
 

--- a/src/image_io.py
+++ b/src/image_io.py
@@ -1,0 +1,23 @@
+"""Helpers for image metadata stored beside media files."""
+
+from pathlib import Path
+
+from serde_utils import write_md, parse_md
+from log_utils import get_logger
+
+log = get_logger().bind(module=__name__)
+
+
+def read_image_meta(path: Path) -> dict[str, str]:
+    """Return metadata from ``path.with_suffix('.md')``."""
+    meta_path = path.with_suffix('.md')
+    meta, _ = parse_md(meta_path)
+    return meta
+
+
+def write_image_meta(path: Path, meta: dict[str, str]) -> None:
+    """Write ``meta`` to ``path.with_suffix('.md')``."""
+    lines = [f"{k}: {v}" for k, v in meta.items() if v]
+    write_md(path.with_suffix('.md'), "\n".join(lines))
+    log.debug("Wrote image meta", path=str(path.with_suffix('.md')))
+

--- a/src/lot_io.py
+++ b/src/lot_io.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Serialise and validate lot JSON files."""
+
+from pathlib import Path
+from typing import Iterable
+
+from log_utils import get_logger
+from serde_utils import load_json, write_json
+
+log = get_logger().bind(module=__name__)
+
+
+def read_lots(path: Path) -> list[dict] | None:
+    """Return a list of lots from ``path`` or ``None`` when invalid."""
+    data = load_json(path)
+    if data is None:
+        return None
+    items = data if isinstance(data, list) else [data]
+    cleaned = []
+    for item in items:
+        if not isinstance(item, dict):
+            log.error("Lot is not dict", file=str(path))
+            return None
+        cleaned.append({k: v for k, v in item.items() if v not in ("", None, [])})
+    return cleaned
+
+
+def write_lots(path: Path, lots: Iterable[dict]) -> None:
+    """Write lots to ``path`` using consistent JSON formatting."""
+    write_json(path, list(lots))
+    log.debug("Wrote lots", path=str(path))
+

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -6,26 +6,12 @@ import ast
 from pathlib import Path
 
 from log_utils import get_logger
-from notes_utils import read_md
+from post_io import read_post
+from caption_io import read_caption
 
 log = get_logger().bind(module=__name__)
 
 
-def parse_md(path: Path) -> tuple[dict[str, str], str]:
-    """Return metadata dictionary and body text from ``path``."""
-    text = path.read_text(encoding="utf-8") if path.exists() else ""
-    lines = text.splitlines()
-    meta: dict[str, str] = {}
-    body_start = 0
-    for i, line in enumerate(lines):
-        if not line.strip():
-            body_start = i + 1
-            break
-        if ":" in line:
-            k, v = line.split(":", 1)
-            meta[k.strip()] = v.strip()
-    body = "\n".join(lines[body_start:])
-    return meta, body
 
 
 def build_prompt(text: str, files: list[str], captions: list[str]) -> str:
@@ -40,12 +26,12 @@ def build_prompt(text: str, files: list[str], captions: list[str]) -> str:
 
 def gather_chop_input(msg_path: Path, media_dir: Path) -> str:
     """Return the exact text fed to the lot parser for ``msg_path``."""
-    meta, text = parse_md(msg_path)
+    meta, text = read_post(msg_path)
     files = ast.literal_eval(meta.get("files", "[]")) if "files" in meta else []
     captions = []
     for rel in files:
         cap_path = (media_dir / rel).with_suffix(".caption.md")
-        caption_text = read_md(str(cap_path))
+        caption_text = read_caption(cap_path)
         captions.append(caption_text)
     prompt = build_prompt(text, files, captions)
     log.debug("Built parser input", path=str(msg_path))

--- a/src/notes_utils.py
+++ b/src/notes_utils.py
@@ -1,28 +1,13 @@
 """Small helper functions to read and write markdown files."""
 
+"""Compatibility wrappers around :mod:`serde_utils` for notes."""
+
 from pathlib import Path
 
 from log_utils import get_logger
+from serde_utils import read_md, read_text, write_md
 
 log = get_logger().bind(module=__name__)
-
-
-def read_text(path: str) -> str:
-    p = Path(path)
-    if not p.exists():
-        return ""
-    return p.read_text(encoding="utf-8")
-
-
-def read_md(path: str) -> str:
-    return read_text(path)
-
-
-def write_md(path: str, text: str) -> None:
-    p = Path(path)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(text.rstrip() + "\n", encoding="utf-8")
-    log.debug("Wrote file", path=str(p))
 
 
 def collect_notes() -> str:
@@ -32,5 +17,5 @@ def collect_notes() -> str:
         return ""
     parts = []
     for f in sorted(notes_dir.glob("*.md")):
-        parts.append(f.read_text(encoding="utf-8"))
+        parts.append(read_md(f))
     return "\n\n".join(parts)

--- a/src/post_io.py
+++ b/src/post_io.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Read and write raw Telegram posts stored as Markdown."""
+
+from pathlib import Path
+
+from log_utils import get_logger
+from serde_utils import parse_md, write_md
+
+log = get_logger().bind(module=__name__)
+
+
+def read_post(path: Path) -> tuple[dict[str, str], str]:
+    """Return metadata dictionary and body text for ``path``."""
+    meta, text = parse_md(path)
+    for k, v in list(meta.items()):
+        if isinstance(v, str) and v.isdigit():
+            meta[k] = int(v)
+    return meta, text
+
+
+def write_post(path: Path, meta: dict[str, str], body: str) -> None:
+    """Write metadata and body as a Markdown post."""
+    meta_lines = [f"{k}: {v}" for k, v in meta.items() if v is not None]
+    write_md(path, "\n".join(meta_lines) + "\n\n" + body.strip())
+    log.debug("Wrote post", path=str(path))
+

--- a/src/serde_utils.py
+++ b/src/serde_utils.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Helpers for reading and writing project files.
+
+The pipeline passes Markdown messages through several stages and stores
+intermediate results as JSON.  This module centralises I/O helpers so
+validation and logging are consistent everywhere.
+"""
+
+import json
+from pathlib import Path
+
+from log_utils import get_logger
+
+log = get_logger().bind(module=__name__)
+
+
+def read_text(path: str | Path) -> str:
+    """Return file contents as UTF-8 or empty string when missing."""
+    p = Path(path)
+    if not p.exists():
+        log.debug("read_text missing", path=str(p))
+        return ""
+    return p.read_text(encoding="utf-8")
+
+
+def read_md(path: str | Path) -> str:
+    """Alias for :func:`read_text` used for Markdown files."""
+    return read_text(path)
+
+
+def write_md(path: str | Path, text: str) -> None:
+    """Write ``text`` to ``path`` ensuring a trailing newline."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text.rstrip() + "\n", encoding="utf-8")
+    log.debug("Wrote markdown", path=str(p))
+
+
+def parse_md(path: Path) -> tuple[dict[str, str], str]:
+    """Return metadata dictionary and body text from ``path``."""
+    text = read_md(path)
+    lines = text.splitlines()
+    meta: dict[str, str] = {}
+    body_start = 0
+    for i, line in enumerate(lines):
+        if not line.strip():
+            body_start = i + 1
+            break
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip()
+    body = "\n".join(lines[body_start:])
+    return meta, body
+
+
+def load_json(path: Path):
+    """Return parsed JSON or ``None`` when invalid."""
+    if not path.exists():
+        log.warning("File not found", path=str(path))
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        log.exception("Failed to parse JSON", file=str(path))
+        return None
+
+
+def write_json(path: Path, data) -> None:
+    """Serialise ``data`` to ``path`` with standard options."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    log.debug("Wrote JSON", path=str(path))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from notes_utils import write_md, read_md
 from token_utils import estimate_tokens
+from post_io import write_post, read_post
+from caption_io import write_caption, read_caption
+from lot_io import write_lots, read_lots
 
 
 def test_write_and_read_md(tmp_path: Path):
@@ -18,3 +21,26 @@ def test_estimate_tokens():
     assert estimate_tokens("") == 0
     assert estimate_tokens("abcd") == 1
     assert estimate_tokens("a" * 20) == 5
+
+
+def test_post_roundtrip(tmp_path: Path):
+    path = tmp_path / "post.md"
+    write_post(path, {"id": 1, "chat": "test"}, "body")
+    meta, text = read_post(path)
+    assert meta["id"] == 1
+    assert text == "body"
+
+
+def test_caption_roundtrip(tmp_path: Path):
+    path = tmp_path / "cap.md"
+    write_caption(path, "cap")
+    assert read_caption(path) == "cap\n"
+
+
+def test_lot_roundtrip(tmp_path: Path):
+    path = tmp_path / "lot.json"
+    lots = [{"a": 1, "b": "x", "c": ""}]
+    write_lots(path, lots)
+    data = read_lots(path)
+    assert data == [{"a": 1, "b": "x"}]
+


### PR DESCRIPTION
## Summary
- create `post_io.py`, `caption_io.py`, `image_io.py` and `lot_io.py`
- refactor services to use the new helpers
- document IO helpers in README and service guide
- cover the new helpers with tests

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dd55fde08324992ec8199863af97