### PR TITLE
Handle fraud-tagged posts in moderation and ontology

### DIFF
--- a/data/ontology/README.md
+++ b/data/ontology/README.md
@@ -11,6 +11,7 @@ The directory contains:
 - `fields.json` – all keys and values with usage counts.
 - `misparsed.json` – lots that failed validation together with the text fed
   into the parser.
+- `fraud.json` – lots flagged with a `fraud` field and the matching input.
 - `broken_meta.json` – references to raw messages that need to be re-fetched
   due to missing metadata.
 - `title_*.json` and `description_*.json` – lists of unique text per language

--- a/docs/ontology_housekeeping.md
+++ b/docs/ontology_housekeeping.md
@@ -20,6 +20,8 @@ The command writes several JSON files under `data/ontology`:
 - `fields.json` – all keys with value counts.
 - `misparsed.json` – lots that failed validation together with the input
   text passed to the parser.
+- `fraud.json` – lots explicitly flagged with a `fraud` tag and the text
+  that produced them.
 - `broken_meta.json` – references to messages that need refetching.
 - `title_*.json` and `description_*.json` – unique values per language for
   manual review.

--- a/docs/services.md
+++ b/docs/services.md
@@ -132,6 +132,7 @@ lot parser under the `input` key so issues can be reproduced. After collecting t
 noisy fields like timestamps and language specific duplicates so the output
 focuses on meaningful attributes. Run `make ontology` to generate the files for
 manual inspection.
+Lots containing a `fraud` field are listed separately in `fraud.json` with the text that produced them.
 If `data/raw` is not present the script will exit early to avoid overwriting the
 tracked JSON files. In that case simply review what is already under
 `data/ontology`.

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -52,6 +52,9 @@ def should_skip_message(meta: dict, text: str) -> bool:
 
 def should_skip_lot(lot: dict) -> bool:
     """Return ``True`` when the lot fails additional checks."""
+    if lot.get("fraud") is not None:
+        log.debug("Lot rejected", reason="fraud", id=lot.get("_id"))
+        return True
     if lot.get("contact:telegram") == "@username":
         log.debug("Lot rejected", reason="example contact")
         return True

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -18,3 +18,17 @@ def test_should_skip_lot():
     assert not moderation.should_skip_lot({"contact:telegram": "@real", "title_en": "x", "description_en": "d", "title_ru": "x", "description_ru": "d", "title_ka": "x", "description_ka": "d"})
     incomplete = {"contact:telegram": "@real", "title_en": "x"}
     assert moderation.should_skip_lot(incomplete)
+
+
+def test_should_skip_fraud():
+    lot = {
+        "fraud": "drugs",
+        "contact:telegram": "@real",
+        "title_en": "x",
+        "description_en": "d",
+        "title_ru": "x",
+        "description_ru": "d",
+        "title_ka": "x",
+        "description_ka": "d",
+    }
+    assert moderation.should_skip_lot(lot)

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -13,6 +13,7 @@ def test_collect_ontology(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "FIELDS_FILE", tmp_path / "fields.json")
     monkeypatch.setattr(scan_ontology, "MISPARSED_FILE", tmp_path / "misparsed.json")
     monkeypatch.setattr(scan_ontology, "BROKEN_META_FILE", tmp_path / "broken.json")
+    monkeypatch.setattr(scan_ontology, "FRAUD_FILE", tmp_path / "fraud.json")
     monkeypatch.setattr(scan_ontology, "RAW_DIR", tmp_path)
     monkeypatch.setattr(scan_ontology, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(
@@ -24,7 +25,7 @@ def test_collect_ontology(tmp_path, monkeypatch):
     (tmp_path / "sub").mkdir()
     (tmp_path / "a.json").write_text(json.dumps([
         {"a": 1, "b": "x", "title_en": "foo"},
-        {"a": 2, "b": "x", "title_en": "bar"}
+        {"a": 2, "b": "x", "title_en": "bar", "fraud": "drugs"}
     ]))
     (tmp_path / "sub" / "b.json").write_text(json.dumps({"b": "y", "c": [1, 2], "title_en": "foo"}))
 
@@ -43,6 +44,10 @@ def test_collect_ontology(tmp_path, monkeypatch):
     # all lots lack translated descriptions so they end up misparsed
     assert mis[0]["lot"]["a"] == 1
 
+    fraud = json.loads((tmp_path / "fraud.json").read_text())
+    assert len(fraud) == 1
+    assert fraud[0]["lot"]["fraud"] == "drugs"
+
 
 def test_skip_fields_are_removed(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "LOTS_DIR", tmp_path)
@@ -52,6 +57,7 @@ def test_skip_fields_are_removed(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "BROKEN_META_FILE", tmp_path / "broken.json")
     monkeypatch.setattr(scan_ontology, "RAW_DIR", tmp_path)
     monkeypatch.setattr(scan_ontology, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(scan_ontology, "FRAUD_FILE", tmp_path / "fraud.json")
     monkeypatch.setattr(
         scan_ontology,
         "REVIEW_FILES",
@@ -91,6 +97,7 @@ def test_empty_values_dropped(tmp_path, monkeypatch):
         "REVIEW_FILES",
         {f: tmp_path / f"{f}.json" for f in scan_ontology.REVIEW_FIELDS},
     )
+    monkeypatch.setattr(scan_ontology, "FRAUD_FILE", tmp_path / "fraud.json")
 
     (tmp_path / "a.json").write_text(json.dumps({"a": "", "b": None, "title_en": "x"}))
 
@@ -109,6 +116,7 @@ def test_broken_meta_list(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_ontology, "BROKEN_META_FILE", tmp_path / "broken.json")
     monkeypatch.setattr(scan_ontology, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(scan_ontology, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(scan_ontology, "FRAUD_FILE", tmp_path / "fraud.json")
     monkeypatch.setattr(
         scan_ontology,
         "REVIEW_FILES",
@@ -147,3 +155,4 @@ def test_no_lots_no_output(tmp_path, monkeypatch):
     scan_ontology.main()
 
     assert not (tmp_path / "fields.json").exists()
+    assert not (tmp_path / "fraud.json").exists()


### PR DESCRIPTION
## Summary
- skip lots marked with `fraud` in `moderation.py`
- track fraud posts in new `fraud.json`
- document `fraud.json` in ontology docs
- collect fraud data in `scan_ontology.py`
- extend tests for moderation and ontology

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fb3ded108324b02af4e348987609