### PR TITLE
Improve fraud prompts

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -149,6 +149,8 @@ posts never reach the website. Update the library with new rules and rerun the
 script to clean past data.
 Recent filters catch offers of illegal narcotics and vague job ads like
 "ищу людей на неполный рабочий день" so they never reach the website.
+Loan promises or token giveaways ("Дам в долг", "Помогу с деньгами", "чем раньше они войдут, тем больше смогут забрать в халявной раздаче токенов") are treated as scams.
+Job offers quoting salary in Russian roubles are considered sketchy for Georgia where wages are usually in GEL or USD.
 
 ## File I/O helpers
 `post_io.py`, `lot_io.py`, `caption_io.py` and `image_io.py` handle posts,

--- a/prompts/chopper_prompt.md
+++ b/prompts/chopper_prompt.md
@@ -62,6 +62,8 @@ Craft `title_<lang>` and `description_<lang>` for every lot using both the origi
   `fraud=sketchy_job`. Leaflet distribution or other ad-hoc explained ones are not to be marked as fraud.
   Posts offering illegal narcotics or other prohibited drugs should be flagged with `fraud=drugs`.
   Simple manual labour requests like "перенести/разгрузить" are normal unqualified jobs and not fraudulent.
+  Salaries quoted in Russian roubles for work in Georgia are suspicious – mark such lots with `fraud=sketchy_job`.
+  Quick money schemes promising loans or token giveaways ("Дам в долг", "Помогу с деньгами", "чем раньше они войдут, тем больше смогут забрать в халявной раздаче токенов") must be flagged with `fraud=scam`.
 - **Community / Events** – `event_invite`, `event_seek`, `announcement`.
   Keys: `event:type`, `date`, `location`, `fee`, `contact:*`.
 - Anything outside these groups should be placed under `misc` until patterns emerge.


### PR DESCRIPTION
## Summary
- expand fraud detection prompts with scam and sketchy job hints
- document new rules in services docs

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_6856ffc053e883248f7b3f2c17fea466