### PR TITLE
Fix gettext missing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install gettext
+        run: sudo apt-get update && sudo apt-get install -y gettext
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,4 +1,4 @@
 # Maintenance
 
 Translations for website templates live under `locale/` as gettext `messages.po` files. Edit `locale/en/LC_MESSAGES/messages.po` to add new strings then update every other language.
-Run `make precommit` to compile the `.po` files and verify that all languages contain every string.
+`msgfmt` from the `gettext` package is needed to compile `.po` files. Run `make precommit` to compile the translations and verify that all languages contain every string.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,8 @@ sudo apt install python3-openai \
     python3-python-telegram-bot \
     python3-jinja2 \
     python3-structlog python3-telethon \
-    python3-sklearn python3-progressbar2
+    python3-sklearn python3-progressbar2 \
+    gettext  # provides msgfmt used to compile translations
 ```
 
 If you prefer isolated dependencies create a virtual environment and use the


### PR DESCRIPTION
## Summary
- install gettext for msgfmt in CI
- document gettext requirement

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857062998b08324a2c93b362df4f659