### PR TITLE
Improve Telegram refetches

### DIFF
--- a/docs/ontology_housekeeping.md
+++ b/docs/ontology_housekeeping.md
@@ -25,6 +25,9 @@ The command writes several JSON files under `data/ontology`:
 - `fraud.json` – lots explicitly flagged with a `fraud` tag and the text
   that produced them.
 - `broken_meta.json` – references to messages that need refetching.
+- `misparsed.json` – used by `tg_client.py` to refetch raw posts whose lots
+  looked suspicious. Updated content causes the existing JSON lots to be
+  dropped so they will be parsed again.
 - `title_*.json` and `description_*.json` – unique values per language for
   manual review.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -41,6 +41,10 @@ Uses Telethon to mirror the target chats as a normal user account.
   are skipped with a warning.  The client ignores videos (`.mp4`), audio files,
   images larger than ten megabytes and any media attached to messages more than
   two days old.
+* **Automatic refetch.** Messages listed in `misparsed.json` are reloaded at
+  startup. If the content changed their corresponding lot files are removed so
+  the parser runs again. Posts that saved neither text nor images are also
+  re-fetched in case Telegram failed to deliver them the first time.
 
 Metadata fields include at least:
 

--- a/src/chop.py
+++ b/src/chop.py
@@ -79,6 +79,10 @@ def process_message(msg_path: Path) -> None:
             caption_text = read_caption(cap)
             log.debug("Found caption", file=str(p), text=caption_text)
             captions.append(caption_text)
+
+    if not text.strip() and not captions:
+        log.info("Skipping message", path=str(msg_path), reason="empty")
+        return
     # Combine the original message text with image captions. This ensures GPT
     # has full context rather than captions alone.
     prompt = build_prompt(text, files, captions)


### PR DESCRIPTION
## Summary
- retry posts listed in `misparsed.json` and drop lots if they change
- retry posts that ended up empty
- skip lots with no text or pictures
- document ontology files and new refetch step

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68570aa3fdc48324a5b09347f94b4689