### PR TITLE
Clean up vectors before similarity

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -112,7 +112,8 @@ applicable so that every language has a meaningful summary.
 Renders the static marketplace website using Jinja templates.  Lots are read
 from `data/lots` and written to `data/views`.  The script loads
 `ontology/fields.json` to order attribute tables and embeddings from `data/vectors` to suggest
-similar lots.  Similarity search now uses `scikit-learn` to find nearest
+similar lots.  Vector files without a matching lot are dropped before computing
+similarity so stale data never bloats memory. Similarity search now uses `scikit-learn` to find nearest
 neighbours efficiently. Each lot page shows images in a small carousel,
 scaled to at most 40% of the viewport height, a table of
 all recognised fields and a link back to the Telegram post.  Pages are

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -315,6 +315,18 @@ def main() -> None:
     lots = _iter_lots()
     _copy_images(lots)
 
+    # Clean up mismatched data before working on vectors.
+    lot_keys = {_lot_id_for(lot["_file"]) for lot in lots}
+    vec_keys = set(vectors)
+    extra_vecs = vec_keys - lot_keys
+    if extra_vecs:
+        for key in extra_vecs:
+            vectors.pop(key, None)
+        log.debug("Dropped vectors without lots", count=len(extra_vecs))
+    missing_vecs = lot_keys - vec_keys
+    if missing_vecs:
+        log.debug("Lots missing vectors", count=len(missing_vecs))
+
     # Map each lot id to its embedding vector if available.
     id_to_vec = {lot["_id"]: vectors.get(_lot_id_for(lot["_file"])) for lot in lots}
 


### PR DESCRIPTION
## Summary
- prune unmatched vectors when building the static site
- document that old vectors are dropped

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68572499e0308324b6dfc33305a73506