### PR TITLE
Avoid empty announcements

### DIFF
--- a/src/moderation.py
+++ b/src/moderation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
-from pathlib import Path
+import ast
 
 from log_utils import get_logger
 from post_io import read_post
@@ -78,6 +78,15 @@ def should_skip_message(meta: dict, text: str) -> bool:
         return True
     if should_skip_text(text):
         log.debug("Message rejected", id=meta.get("id"))
+        return True
+    files: list[str] = []
+    if "files" in meta:
+        try:
+            files = ast.literal_eval(meta.get("files", "[]"))
+        except Exception:
+            log.debug("Bad file list", value=meta.get("files"), id=meta.get("id"))
+    if not text.strip() and not files:
+        log.debug("Message rejected", reason="empty", id=meta.get("id"))
         return True
     return False
 

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -17,6 +17,12 @@ def test_skip_due_to_media_flag():
     assert moderation.should_skip_message(meta, "text")
 
 
+def test_skip_due_to_empty_message():
+    assert moderation.should_skip_message({}, "")
+    meta = {"files": "['x.jpg']"}
+    assert not moderation.should_skip_message(meta, "")
+
+
 def test_should_skip_lot():
     lot = {"contact:telegram": "@username"}
     assert moderation.should_skip_lot(lot)


### PR DESCRIPTION
## Summary
- skip messages with no text and no files during moderation
- test empty message handling

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572718ebbc83248826d9d8d7797438