### PR TITLE
Clean orphan vectors

### DIFF
--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -20,6 +20,7 @@ KEEP_DAYS = getattr(cfg, "KEEP_DAYS", 7)
 RAW_DIR = Path("data/raw")
 MEDIA_DIR = Path("data/media")
 LOTS_DIR = Path("data/lots")
+VEC_DIR = Path("data/vectors")
 
 
 def _parse_date(md: Path) -> datetime | None:
@@ -85,6 +86,21 @@ def _clean_lots() -> None:
         log.info("Removed stale lots", count=count)
 
 
+def _clean_vectors() -> None:
+    """Delete vector files when the matching lot JSON is absent."""
+    count = 0
+    if not VEC_DIR.exists():
+        return
+    for path in VEC_DIR.rglob("*.json"):
+        lot = LOTS_DIR / path.relative_to(VEC_DIR)
+        if not lot.exists():
+            path.unlink()
+            log.info("Deleted vector", file=str(path))
+            count += 1
+    if count:
+        log.info("Removed orphan vectors", count=count)
+
+
 def _remove_empty_dirs(root: Path) -> None:
     """Recursively remove empty folders under ``root``."""
     count = 0
@@ -105,7 +121,8 @@ def main() -> None:
     _clean_raw(cutoff)
     _clean_media(cutoff)
     _clean_lots()
-    for root in [RAW_DIR, MEDIA_DIR, LOTS_DIR]:
+    _clean_vectors()
+    for root in [RAW_DIR, MEDIA_DIR, LOTS_DIR, VEC_DIR]:
         _remove_empty_dirs(root)
 
 

--- a/tests/test_clean_data.py
+++ b/tests/test_clean_data.py
@@ -18,6 +18,7 @@ def test_clean_data(tmp_path, monkeypatch):
     monkeypatch.setattr(clean_data, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(clean_data, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(clean_data, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(clean_data, "VEC_DIR", tmp_path / "vecs")
     monkeypatch.setattr(clean_data, "load_config", lambda: DummyCfg())
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=DummyCfg.KEEP_DAYS + 1)
@@ -65,6 +66,17 @@ def test_clean_data(tmp_path, monkeypatch):
     empty_lot = lot_empty_dir / "3.json"
     empty_lot.write_text(json.dumps([{"_id": "3", "source:path": "oldchat/2024/05/1.md"}]))
 
+    vec_dir = clean_data.VEC_DIR / "chat" / "2024" / "05"
+    vec_dir.mkdir(parents=True)
+    v_old = vec_dir / "1.json"
+    v_old.write_text("oldvec")
+    v_new = vec_dir / "2.json"
+    v_new.write_text("newvec")
+    orphan_dir = clean_data.VEC_DIR / "orphan" / "2024" / "05"
+    orphan_dir.mkdir(parents=True)
+    v_orphan = orphan_dir / "3.json"
+    v_orphan.write_text("orphan")
+
     clean_data.main()
 
     assert not raw_old.exists()
@@ -77,3 +89,7 @@ def test_clean_data(tmp_path, monkeypatch):
     assert not old_lot.exists()
     assert new_lot.exists()
     assert not lot_empty_dir.exists()
+    assert not v_old.exists()
+    assert v_new.exists()
+    assert not v_orphan.exists()
+    assert not orphan_dir.exists()


### PR DESCRIPTION
## Summary
- tidy up after pipeline runs by deleting vectors without lots
- cover vector cleanup in tests

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572a10621883249f8bcf49da66e42f