### PR TITLE
Trigger lot parsing from Telegram client

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ file is skipped because the caption already exists. Run `make caption` to
 (re)process any images that might have missed automatic captioning. Unicode
 characters, including Cyrillic, are stored verbatim so logs remain easy to
 read.
+Lots are parsed automatically once captions finish so new posts show up on the
+site without additional commands.
 
 Domain specific helpers like `src/post_io.py`, `src/lot_io.py` and
 `src/caption_io.py` provide validated loading and saving of posts,

--- a/docs/services.md
+++ b/docs/services.md
@@ -83,7 +83,9 @@ original. Captions are later included in the lot chopper prompt where the
 `chop.py` script lists every `Image <filename>` before its caption. This makes
 it crystal clear which picture the text belongs to. When `LOG_LEVEL` is set to
 `INFO`, the script logs each processed filename along with the generated
-caption.
+caption. Once a message and all its captions are written, `tg_client.py`
+spawns `chop.py` in the background so lots appear without waiting for the
+next `make chop` run.
 If some captions are missing you can run `make caption` to retry processing
 all images.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,8 +46,8 @@ make compose
 
 `make update` continues to work as an alias for this pipeline.
 
-This pulls messages (images are captioned immediately), chops lots, generates embeddings and finally builds the static site.
-Run `make caption` separately if you need to reprocess failed images.
+This pulls messages (images are captioned immediately and lots are parsed in the background), generates embeddings and finally builds the static site.
+Run `make caption` or `make chop` separately if you need to reprocess failed images.
 
 Run the test suite and linter before committing:
 


### PR DESCRIPTION
## Summary
- trigger `chop.py` after each message is saved
- skip lot extraction during tests
- document automatic lot parsing
- update setup instructions
- mention background lot parsing in README
- test that lots are scheduled on save

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685750df1720832491faf71dab113c9f