### PR TITLE
Improve embedding workflow

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -110,9 +110,13 @@ processed at once. The API call specifies `response_format={"type":
 "json_object"}` so GPT-4o returns plain JSON without Markdown wrappers.
 
 ## embed.py
-Generates `text-embedding-3-large` vectors for each message file.  The output is
-stored under `data/vectors/` mirroring the layout of `data/lots`.  GNU Parallel
-processes the newest files first so search results are quickly refreshed.
+Generates `text-embedding-3-large` vectors for each lot.  The output is stored
+under `data/vectors/` mirroring the layout of `data/lots`.  Each file contains a
+list of `{id, vec}` pairs so multiple lots share a single vector file.  GNU
+Parallel processes the newest files first so search results are quickly
+refreshed. `pending_embed.py` upgrades any leftover single-object files by
+wrapping them in a list and deletes mismatched ones so stale vectors never pollute
+the index.
 
 Translations are now produced by `chop.py` itself.  Fields like
 `title_ru` or `description_ka` are included in the lot JSON directly. Titles

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,7 +46,7 @@ make compose
 
 `make update` continues to work as an alias for this pipeline.
 
-This pulls messages (images are captioned immediately and lots are parsed in the background), generates embeddings and finally builds the static site.
+This pulls messages (images are captioned immediately and lots are parsed in the background). Chopped lots trigger embedding right away so vectors stay in sync without a separate step. The command finishes by building the static site.
 Run `make caption` or `make chop` separately if you need to reprocess failed images.
 
 Run the test suite and linter before committing:

--- a/scripts/pending_embed.py
+++ b/scripts/pending_embed.py
@@ -1,18 +1,66 @@
 #!/usr/bin/env python3
-"""List lot JSON files needing embeddings."""
+"""List lot JSON files needing embeddings and upgrade legacy vectors."""
 from pathlib import Path
 import sys
+from lot_io import read_lots
+from serde_utils import load_json, write_json
+from log_utils import get_logger
 
 LOTS_DIR = Path("data/lots")
 VEC_DIR = Path("data/vectors")
 
+log = get_logger().bind(script=__file__)
+
+
+def _needs_embed(path: Path, vec: Path, lots: list[dict]) -> bool:
+    """Return ``True`` when ``vec`` is missing or out of date.
+
+    The function upgrades older vector files written as a single object and
+    deletes mismatched files.
+    """
+    if not vec.exists():
+        return True
+    if vec.stat().st_mtime < path.stat().st_mtime:
+        return True
+    data = load_json(vec)
+    if data is None:
+        vec.unlink(missing_ok=True)
+        log.debug("Bad vector file", file=str(vec))
+        return True
+    # Legacy format stored a single {id, vec} object per file
+    if isinstance(data, dict) and "id" in data and "vec" in data:
+        if len(lots) == 1:
+            write_json(vec, [data])
+            log.debug("Upgraded vector", file=str(vec))
+            return False
+        vec.unlink(missing_ok=True)
+        log.debug("Vector count mismatch", file=str(vec), lots=len(lots), vecs=1)
+        return True
+    if isinstance(data, list):
+        if len(data) != len(lots):
+            vec.unlink(missing_ok=True)
+            log.debug(
+                "Vector count mismatch",
+                file=str(vec),
+                lots=len(lots),
+                vecs=len(data),
+            )
+            return True
+        return False
+    vec.unlink(missing_ok=True)
+    log.debug("Unknown vector format", file=str(vec))
+    return True
+
 
 def main() -> None:
-    files = sorted(LOTS_DIR.rglob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    files = sorted(
+        LOTS_DIR.rglob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True
+    )
     for path in files:
+        lots = read_lots(path) or []
         rel = path.relative_to(LOTS_DIR)
         out = (VEC_DIR / rel).with_suffix(".json")
-        if not out.exists() or out.stat().st_mtime < path.stat().st_mtime:
+        if _needs_embed(path, out, lots):
             sys.stdout.write(str(path))
             sys.stdout.write("\0")
 

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -61,6 +61,12 @@ def _load_vectors() -> dict[str, list[float]]:
         obj = load_json(path)
         if isinstance(obj, dict) and "id" in obj and "vec" in obj:
             data[obj["id"]] = obj["vec"]
+        elif isinstance(obj, list):
+            for item in obj:
+                if isinstance(item, dict) and "id" in item and "vec" in item:
+                    data[item["id"]] = item["vec"]
+                else:
+                    log.error("Bad vector entry", file=str(path))
         else:
             log.error("Failed to parse vector file", file=str(path))
     log.info("Loaded vectors", count=len(data))

--- a/src/chop.py
+++ b/src/chop.py
@@ -21,6 +21,7 @@ from log_utils import get_logger, install_excepthook
 from caption_io import read_caption
 from post_io import read_post
 from message_utils import build_prompt
+import embed
 
 # Blueprint describing expected fields and message taxonomy used by the model.
 BLUEPRINT = Path("prompts/chopper_prompt.md").read_text(encoding="utf-8")
@@ -132,6 +133,10 @@ def process_message(msg_path: Path) -> None:
             lot.setdefault(f"description_{lang}", "")
     out.write_text(json.dumps(lots, ensure_ascii=False, indent=2))
     log.debug("Wrote", path=str(out))
+    try:
+        embed.embed_file(out)
+    except Exception:
+        log.exception("Embedding failed", path=str(out))
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -8,7 +8,11 @@ dummy_openai = types.ModuleType("openai")
 class DummyEmbeddings:
     @staticmethod
     def create(*a, **k):
-        return types.SimpleNamespace(data=[types.SimpleNamespace(embedding=[1,2,3])])
+        # return an embedding for every input item
+        n = len(k.get("input", [])) if isinstance(k.get("input"), list) else 1
+        return types.SimpleNamespace(
+            data=[types.SimpleNamespace(embedding=[1, 2, 3]) for _ in range(n)]
+        )
 
 dummy_openai.embeddings = DummyEmbeddings()
 sys.modules["openai"] = dummy_openai
@@ -26,15 +30,18 @@ import embed
 def test_embed_file(tmp_path, monkeypatch):
     monkeypatch.setattr(embed, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(embed, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(embed, "openai", dummy_openai)
 
     path = tmp_path / "lots" / "chat" / "2024" / "05" / "1.json"
     path.parent.mkdir(parents=True)
-    path.write_text("text")
+    path.write_text(json.dumps([{"a": 1}, {"a": 2}]))
 
     embed.main([str(path)])
 
     out = tmp_path / "vecs" / "chat" / "2024" / "05" / "1.json"
     assert out.exists()
     data = json.loads(out.read_text())
-    assert data["id"] == "chat/1"
-    assert data["vec"] == [1,2,3]
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["id"] == "chat/1-0"
+    assert data[0]["vec"] == [1, 2, 3]

--- a/tests/test_pending_embed.py
+++ b/tests/test_pending_embed.py
@@ -1,0 +1,47 @@
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pending_embed
+from serde_utils import load_json
+
+
+def test_upgrade_legacy_format(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(pending_embed, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(pending_embed, "VEC_DIR", tmp_path / "vecs")
+
+    path = pending_embed.LOTS_DIR / "1.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps([{"a": 1}]))
+
+    vec = pending_embed.VEC_DIR / "1.json"
+    vec.parent.mkdir(parents=True)
+    vec.write_text(json.dumps({"id": "x", "vec": [1]}))
+
+    pending_embed.main()
+    out = capsys.readouterr().out
+    assert out == ""
+    data = load_json(vec)
+    assert isinstance(data, list)
+    assert data[0]["id"] == "x"
+
+
+def test_vector_count_mismatch(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(pending_embed, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(pending_embed, "VEC_DIR", tmp_path / "vecs")
+
+    path = pending_embed.LOTS_DIR / "1.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps([{"a": 1}, {"a": 2}]))
+
+    vec = pending_embed.VEC_DIR / "1.json"
+    vec.parent.mkdir(parents=True)
+    vec.write_text(json.dumps([{"id": "x", "vec": [1]}]))
+
+    pending_embed.main()
+    out = capsys.readouterr().out
+    assert out == str(path) + "\0"
+    assert not vec.exists()


### PR DESCRIPTION
## Summary
- embed lots individually instead of single message json
- trigger embedding when chopping finishes
- load list-based vectors in site builder
- flag lots with mismatched list lengths as misparsed
- update documentation
- test new behaviour
- upgrade pending_embed to convert old vector files and detect mismatched counts

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575a722a6c8324a53805e06d241e86