### PR TITLE
Fix pending_embed script imports

### DIFF
--- a/scripts/pending_embed.py
+++ b/scripts/pending_embed.py
@@ -2,6 +2,11 @@
 """List lot JSON files needing embeddings and upgrade legacy vectors."""
 from pathlib import Path
 import sys
+# Make ``src`` imports work when executing this script directly from the
+# repository root as done in the Makefile.  Unit tests set ``PYTHONPATH``
+# explicitly so this is only needed for manual runs.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from lot_io import read_lots
 from serde_utils import load_json, write_json
 from log_utils import get_logger

--- a/tests/test_pending_embed.py
+++ b/tests/test_pending_embed.py
@@ -1,5 +1,7 @@
 import sys
 import json
+import os
+import subprocess
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
@@ -45,3 +47,25 @@ def test_vector_count_mismatch(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert out == str(path) + "\0"
     assert not vec.exists()
+
+
+def test_cli_runs(tmp_path):
+    """The script should run standalone without PYTHONPATH."""
+    lots_dir = tmp_path / "data" / "lots"
+    lots_dir.mkdir(parents=True)
+    (lots_dir / "1.json").write_text("[]")
+    (tmp_path / "data" / "vectors").mkdir(parents=True)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pending_embed.py"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    out = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert out.stdout == "data/lots/1.json\0"
+    assert out.returncode == 0


### PR DESCRIPTION
## Summary
- make pending_embed.py executable standalone by adding src to `sys.path`
- ensure CLI works via a new unit test

## Testing
- `make precommit`
- `pytest -q`
- `python scripts/pending_embed.py | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_685761a4758c83248188a4b48d601288