### PR TITLE
Makefile caption target skips processed images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ pull: # Pull Telegram messages and media to ``data/``.
 	python src/tg_client.py
 
 caption: pull ## Generate image captions for files missing ``*.caption.md``.
-	find data/media -type f ! -name '*.md' -printf '%T@ %p\0' \
-	| sort -z -nr \
-	| cut -z -d' ' -f2- \
+	python scripts/pending_caption.py \
 	| parallel -j16 -0 python src/caption.py
 	python scripts/validate_outputs.py captions
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Logs are written to `errors.log` in JSON format. Set `LOG_LEVEL` in
 adjust verbosity. When the level is `INFO`, `tg_client.py` logs each
 captioned file along with the generated text. `caption.py` also notes when a
 file is skipped because the caption already exists. Run `make caption` to
-(re)process any images that might have missed automatic captioning. Unicode
+(re)process any images that might have missed automatic captioning. Existing
+captions are detected so rerunning the command does not trigger extra API calls.
+Unicode
 characters, including Cyrillic, are stored verbatim so logs remain easy to
 read.
 Lots are parsed automatically once captions finish so new posts show up on the

--- a/docs/services.md
+++ b/docs/services.md
@@ -90,7 +90,8 @@ present (or there were no images) and the cooldown expires the client spawns
 `chop.py` in the background. This way lots appear quickly without waiting for
 the next `make chop` run and incomplete posts are avoided.
 If some captions are missing you can run `make caption` to retry processing
-all images.
+any uncaptured images. The command skips files that already have captions so
+the API isn't called unnecessarily.
 
 See [chopper_prompt.md](../prompts/chopper_prompt.md) for the schema and taxonomy used by the
 lot chopper. The prompt now includes short title examples and an `item:audience` field to mark

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,6 +48,7 @@ make compose
 
 This pulls messages (images are captioned immediately and lots are parsed in the background). Chopped lots trigger embedding right away so vectors stay in sync without a separate step. The command finishes by building the static site.
 Run `make caption` or `make chop` separately if you need to reprocess failed images.
+`make caption` now skips files that already have captions so reruns are cheap.
 
 Run the test suite and linter before committing:
 

--- a/scripts/pending_caption.py
+++ b/scripts/pending_caption.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""List images that need captions."""
+from pathlib import Path
+import sys
+
+MEDIA_DIR = Path("data/media")
+
+
+def main() -> None:
+    files = sorted(
+        (p for p in MEDIA_DIR.rglob("*") if p.is_file() and p.suffix != ".md"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for path in files:
+        if not path.with_suffix(".caption.md").exists():
+            sys.stdout.write(str(path))
+            sys.stdout.write("\0")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pending_caption.py
+++ b/tests/test_pending_caption.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pending_caption
+
+
+def test_list_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(pending_caption, "MEDIA_DIR", tmp_path / "media")
+
+    img = pending_caption.MEDIA_DIR / "chat" / "2024" / "05" / "img.jpg"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(b"img")
+
+    pending_caption.main()
+    out = capsys.readouterr().out
+    assert out == str(img) + "\0"
+
+
+def test_skip_existing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(pending_caption, "MEDIA_DIR", tmp_path / "media")
+
+    img = pending_caption.MEDIA_DIR / "chat" / "2024" / "05" / "img.jpg"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(b"img")
+    (img.with_suffix(".caption.md")).write_text("cap")
+
+    pending_caption.main()
+    out = capsys.readouterr().out
+    assert out == ""
+
+
+def test_cli_runs(tmp_path):
+    media_dir = tmp_path / "data" / "media" / "chat"
+    media_dir.mkdir(parents=True)
+    (media_dir / "img.jpg").write_bytes(b"d")
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pending_caption.py"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    out = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    expected = str(Path("data/media/chat/img.jpg")) + "\0"
+    assert out.stdout == expected
+    assert out.returncode == 0
+


### PR DESCRIPTION
## Summary
- add `pending_caption.py` listing images without captions
- update caption target to use that script
- document that missing captions are handled automatically
- add tests for `pending_caption.py`

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685764e3b37083249d366840d5b38974