### PR TITLE
Adjust caption request logging

### DIFF
--- a/src/caption.py
+++ b/src/caption.py
@@ -104,7 +104,7 @@ def caption_file(path: Path) -> str:
         },
     ]
     log.debug("Captioning", sha=sha, chat=chat, file=str(path))
-    log.info("OpenAI request", messages=message)
+    log.debug("OpenAI request", messages=message)
     try:
         resp = openai.chat.completions.create(model="gpt-4o-mini", messages=message)
         text = resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- reduce logging noise when sending captioning requests by logging the outgoing GPT messages at DEBUG level

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_68579b97f8b08324a2234f00f3063e29