### PR TITLE
Drop misparsed refetch

### DIFF
--- a/docs/ontology_housekeeping.md
+++ b/docs/ontology_housekeeping.md
@@ -25,9 +25,8 @@ The command writes several JSON files under `data/ontology`:
 - `fraud.json` – lots explicitly flagged with a `fraud` tag and the text
   that produced them.
 - `broken_meta.json` – references to messages that need refetching.
-- `misparsed.json` – used by `tg_client.py` to refetch raw posts whose lots
-  looked suspicious. Updated content causes the existing JSON lots to be
-  dropped so they will be parsed again.
+- `misparsed.json` – lots that looked suspicious. Updating the file causes the
+  corresponding JSON lots to be dropped so they will be parsed again.
 - `title_*.json` and `description_*.json` – unique values per language for
   manual review.
 
@@ -45,7 +44,7 @@ removing it from the prompt to save tokens.
 
 Misparsed lots include the exact text that produced them under the `input`
 key. Inspect a few entries to see why the model struggled. Posts without a
-timestamp or any seller information also end up here so they can be refetched.
+timestamp or any seller information also end up here so they can be reviewed.
 Raw posts missing contact details or a timestamp are treated the same.  The
 helper functions in `lot_io.py` and `post_io.py` determine the seller and
 validate timestamps so both the ontology scan and website stay in agreement.

--- a/docs/services.md
+++ b/docs/services.md
@@ -51,10 +51,9 @@ Uses Telethon to mirror the target chats as a normal user account.
   larger than ten megabytes and any media attached to messages more than two
   days old. Messages marked this way are ignored by `chop.py` so only complete
   posts are parsed.
-* **Automatic refetch.** Messages listed in `misparsed.json` are reloaded at
-  startup. If the content changed their corresponding lot files are removed so
-  the parser runs again. Posts that saved neither text nor images are also
-  re-fetched in case Telegram failed to deliver them the first time.
+* **Automatic cleanup.** Messages listed in `broken_meta.json` or posts saved
+  without text or images are reloaded on startup. If the content changed their
+  corresponding lot files are removed so the parser runs again.
 
 Metadata fields include at least:
 


### PR DESCRIPTION
## Summary
- stop tg_client from reading misparsed.json
- clean up docs to reflect refetch change

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857a0cd9614832482f7e3970bfb2b62