### PR TITLE
Improve broken_meta checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ scanner should not run as it would produce empty files – review the tracked
 JSONs instead.
 
 The ontology files include `broken_meta.json` which lists messages missing
-metadata. `tg_client.py` tries to refetch everything in that list at the start
-of each run.
+mandatory metadata such as the timestamp or post author. `tg_client.py` tries to
+refetch everything in that list at the start of each run.
 `fields.approved.json` in the same folder lists popular fields with short
 English explanations and example values. Each entry contains the tag `key`, a
 `description_en` value and optional `values` describing common options.

--- a/docs/ontology_housekeeping.md
+++ b/docs/ontology_housekeeping.md
@@ -24,7 +24,8 @@ The command writes several JSON files under `data/ontology`:
   text passed to the parser.
 - `fraud.json` – lots explicitly flagged with a `fraud` tag and the text
   that produced them.
-- `broken_meta.json` – references to messages that need refetching.
+- `broken_meta.json` – references to messages that need refetching when the raw
+  metadata lacks a timestamp or author.
 - `misparsed.json` – lots that looked suspicious. Updating the file causes the
   corresponding JSON lots to be dropped so they will be parsed again.
 - `title_*.json` and `description_*.json` – unique values per language for

--- a/docs/services.md
+++ b/docs/services.md
@@ -51,8 +51,9 @@ Uses Telethon to mirror the target chats as a normal user account.
   larger than ten megabytes and any media attached to messages more than two
   days old. Messages marked this way are ignored by `chop.py` so only complete
   posts are parsed.
-* **Automatic cleanup.** Messages listed in `broken_meta.json` or posts saved
-  without text or images are reloaded on startup. If the content changed their
+* **Automatic cleanup.** Messages listed in `broken_meta.json` – posts missing
+  mandatory metadata like the timestamp or author – or messages saved without
+  text or images are reloaded on startup. If the content changed their
   corresponding lot files are removed so the parser runs again.
 
 Metadata fields include at least:
@@ -177,9 +178,9 @@ If `data/raw` is not present the script will exit early to avoid overwriting the
 tracked JSON files. In that case simply review what is already under
 `data/ontology`.
 Lots flagged as misparsed are ignored by `build_site.py` so the website never
-shows incomplete posts.
-Any raw post lacking mandatory metadata is added to `broken_meta.json` so
-`tg_client.py` can refetch it during the next run.
+shows incomplete posts. Any raw post lacking a timestamp or author details is
+added to `broken_meta.json` so `tg_client.py` can refetch it during the next
+run.
 
 ## moderation.py
 Reusable library for spam filtering. `moderation.apply_to_history()` walks

--- a/tests/test_post_io_extra.py
+++ b/tests/test_post_io_extra.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from post_io import get_contact, get_timestamp
+from post_io import get_contact, get_timestamp, is_broken_meta, iter_broken_posts
 
 
 def test_get_contact_priority():
@@ -29,4 +29,27 @@ def test_get_timestamp_parsing():
     assert get_timestamp(meta_past) is not None
     assert get_timestamp(meta_future) is None
     assert get_timestamp(meta_bad) is None
+
+
+def test_is_broken_meta():
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    ok = {"id": 1, "chat": "c", "date": now, "sender_name": "x"}
+    assert not is_broken_meta(ok)
+    assert is_broken_meta({"chat": "c", "date": now, "sender_name": "x"})
+    assert is_broken_meta({"id": 1, "chat": "c", "sender_name": "x"})
+    assert is_broken_meta({"id": 1, "chat": "c", "date": now})
+
+
+def test_iter_broken_posts(tmp_path):
+    raw_dir = tmp_path / "raw"
+    msg_dir = raw_dir / "chat" / "2024" / "05"
+    msg_dir.mkdir(parents=True)
+    (msg_dir / "1.md").write_text("id: 1\nchat: chat\n\n")
+    (msg_dir / "2.md").write_text(
+        "id: 2\nchat: chat\ndate: 2024-05-01T00:00:00+00:00\nsender_name: x\n\ntext"
+    )
+
+    entries = dict(iter_broken_posts(raw_dir))
+    assert ("chat", 1) in entries
+    assert ("chat", 2) not in entries
 

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -887,6 +887,37 @@ def test_refetch_messages(tmp_path, monkeypatch):
     assert not (tmp_path / "broken.json").exists()
 
 
+def test_refetch_due_to_incomplete_meta(tmp_path, monkeypatch):
+    _install_telethon_stub(monkeypatch)
+    cfg = types.ModuleType("config")
+    cfg.TG_API_ID = 0
+    cfg.TG_API_HASH = ""
+    cfg.TG_SESSION = ""
+    cfg.CHATS = []
+    monkeypatch.setitem(sys.modules, "config", cfg)
+
+    tg_client = importlib.reload(importlib.import_module("tg_client"))
+    raw_dir = tmp_path / "raw"
+    monkeypatch.setattr(tg_client, "RAW_DIR", raw_dir)
+    raw = raw_dir / "chat" / "2024" / "05"
+    raw.mkdir(parents=True)
+    # missing date and contact
+    (raw / "1.md").write_text("id: 1\nchat: chat\n\ntext")
+
+    fetched = []
+
+    class DummyClient:
+        async def get_messages(self, chat, ids):
+            fetched.append((chat, ids))
+            return types.SimpleNamespace(id=ids, date=datetime.datetime.now(datetime.timezone.utc), message="")
+
+    monkeypatch.setattr(tg_client, "_save_bounded", lambda c, chat, msg, **_: asyncio.sleep(0))
+
+    asyncio.run(tg_client.refetch_messages(DummyClient()))
+
+    assert ("chat", 1) in fetched
+
+
 def test_refetch_cleanup_deleted(tmp_path, monkeypatch):
     _install_telethon_stub(monkeypatch)
     cfg = types.ModuleType("config")


### PR DESCRIPTION
## Summary
- add `iter_broken_posts()` helper
- use the helper when refetching incomplete posts
- test the helper

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857a26b5cb483249248f4953c7d9b85