### PR TITLE
Fix vector lookup for similar lots

### DIFF
--- a/src/build_site.py
+++ b/src/build_site.py
@@ -3,9 +3,9 @@
 Each ``*.json`` file under ``data/lots`` may contain several lots so we assign
 a unique ``_page_id`` to every entry.  Templates live in ``templates/`` and the
 output is written to ``data/views`` keeping the directory layout intact.  The
-script also loads ``data/vectors.jsonl`` if present to find similar lots based
-on cosine similarity.  ``data/ontology/fields.json`` is consulted to display table
-columns in a stable order.
+script also loads embeddings from ``data/vectors`` if present to find similar
+lots based on cosine similarity.  ``data/ontology/fields.json`` is consulted to
+display table columns in a stable order.
 """
 
 import math
@@ -42,14 +42,6 @@ ONTOLOGY = Path("data/ontology/fields.json")
 RAW_DIR = Path("data/raw")
 LOCALE_DIR = Path("locale")
 MEDIA_DIR = Path("data/media")
-
-
-def _lot_id_for(path: Path) -> str:
-    """Return unique id ``chat/msg_id`` for ``path``."""
-    rel = path.relative_to(LOTS_DIR)
-    chat = rel.parts[0]
-    return f"{chat}/{path.stem}"
-
 
 def _load_vectors() -> dict[str, list[float]]:
     """Return mapping of lot id to embedding vector."""
@@ -314,7 +306,7 @@ def main() -> None:
     _copy_images(lots)
 
     # Clean up mismatched data before working on vectors.
-    lot_keys = {_lot_id_for(lot["_file"]) for lot in lots}
+    lot_keys = {lot["_id"] for lot in lots}
     vec_keys = set(vectors)
     extra_vecs = vec_keys - lot_keys
     if extra_vecs:
@@ -326,7 +318,7 @@ def main() -> None:
         log.debug("Lots missing vectors", count=len(missing_vecs))
 
     # Map each lot id to its embedding vector if available.
-    id_to_vec = {lot["_id"]: vectors.get(_lot_id_for(lot["_file"])) for lot in lots}
+    id_to_vec = {lot["_id"]: vectors.get(lot["_id"]) for lot in lots}
 
     log.info("Computing similar lots", count=len(lots))
     sim_map: dict[str, list[dict]] = {}

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -271,3 +271,61 @@ def test_images_and_empty_values(tmp_path, monkeypatch):
     html = (tmp_path / "views" / "1-0_en.html").read_text()
     assert "extra" not in html
     assert "other" not in html
+
+
+def test_vectors_generate_similar(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    vec_dir = tmp_path / "vecs"
+    vec_dir.mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "a",
+                "description_en": "d",
+                "title_ru": "a",
+                "description_ru": "d",
+                "title_ka": "a",
+                "description_ka": "d",
+                "files": [],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+    (lots_dir / "2.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "b",
+                "description_en": "d",
+                "title_ru": "b",
+                "description_ru": "d",
+                "title_ka": "b",
+                "description_ka": "d",
+                "files": [],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+
+    (vec_dir / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (vec_dir / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build_site.main()
+
+    html = (tmp_path / "views" / "1-0_en.html").read_text()
+    assert "2-0_en.html" in html


### PR DESCRIPTION
## Summary
- load embeddings from `data/vectors` properly
- find vectors by lot id instead of file path
- test that "similar" section works

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857bc7260688324b08f4ba5e347f905