### PR TITLE
Add debug dump script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Define pipeline stages explicitly so ``make -j compose`` executes them in the
 # correct order.  Each stage runs only after its dependency completes.
-.PHONY: compose update pull removed caption chop embed build alert ontology clean precommit
+.PHONY: compose update pull removed caption chop embed build alert ontology clean precommit debugdump
 
 all: clean build removed
 
@@ -36,6 +36,10 @@ build: embed ontology
 # Telegram alert bot for new lots.
 alert: embed
 	python src/alert_bot.py
+
+# Gather logs and related files for one lot.
+debugdump:
+	python src/debug_dump.py "$(URL)"
 
 clean:
 	python src/clean_data.py

--- a/docs/services.md
+++ b/docs/services.md
@@ -206,6 +206,14 @@ directories are created automatically.
 `get_timestamp()` which both the ontology scanner and site builder use to stay
 in sync.
 
+## debug_dump.py
+Collects everything related to a single lot into one text block.
+Pass a page URL and the script will trim the hostname, run
+`tg_client.py --fetch` on the underlying Telegram post and then append
+the resulting logs along with the lot JSON, vector file and raw post.
+Captions and image metadata are included when present so the entire
+pipeline state can be shared in one go.
+
 ## Makefile
 The `Makefile` in the repository root wires these scripts together. Running
 `make compose` performs a full refresh: pulling messages (images are captioned on

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -326,7 +326,10 @@ def main() -> None:
     vec_ids = [lot["_id"] for lot in lots if id_to_vec.get(lot["_id"])]
     if _has_sklearn and vec_ids:
         matrix = [id_to_vec[i] for i in vec_ids]
-        nn = NearestNeighbors(n_neighbors=7, metric="cosine")
+        # ``kneighbors`` raises when ``n_neighbors`` exceeds the number of
+        # vectors, so keep the value within bounds.
+        k = min(7, len(matrix))
+        nn = NearestNeighbors(n_neighbors=k, metric="cosine")
         nn.fit(matrix)
         dists, idxs = nn.kneighbors(matrix)
         idx_to_id = {i: vec_ids[i] for i in range(len(vec_ids))}

--- a/src/debug_dump.py
+++ b/src/debug_dump.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+"""Collect debug info for a single lot.
+
+The script accepts a URL pointing to a generated HTML page and gathers
+all related files for that lot. The Telegram client is invoked with
+``--fetch`` so message metadata can be refreshed. Logs, lots, vectors and
+raw posts are concatenated into a single output suitable for copy/paste
+when troubleshooting the pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from caption_io import read_caption
+from serde_utils import read_text, load_json
+from log_utils import get_logger
+
+log = get_logger().bind(script=__file__)
+
+LOTS_DIR = Path("data/lots")
+VEC_DIR = Path("data/vectors")
+RAW_DIR = Path("data/raw")
+MEDIA_DIR = Path("data/media")
+
+
+def parse_lot_id(url: str) -> tuple[str, str | None]:
+    """Return ``(lot_id, lang)`` extracted from ``url``."""
+    path = urlparse(url).path.lstrip("/")
+    if path.endswith(".html"):
+        path = path[:-5]
+    if "_" in path:
+        lot_id, lang = path.rsplit("_", 1)
+    else:
+        lot_id, lang = path, None
+    return lot_id, lang
+
+
+def load_source_info(lot_id: str) -> tuple[str | None, int | None]:
+    """Return ``(chat, message_id)`` for ``lot_id`` if available."""
+    lot_path = LOTS_DIR / f"{lot_id}.json"
+    lot_data = load_json(lot_path)
+    if not lot_data:
+        log.warning("Lot file missing", lot=lot_id)
+        return None, None
+    lot = lot_data[0] if isinstance(lot_data, list) else lot_data
+    chat = lot.get("source:chat")
+    mid = lot.get("source:message_id")
+    if (chat is None or mid is None) and lot.get("source:path"):
+        parts = Path(str(lot["source:path"])).parts
+        if len(parts) >= 4:
+            chat = chat or parts[0]
+            try:
+                mid = mid or int(Path(parts[-1]).stem)
+            except ValueError:
+                mid = None
+    return chat, mid
+
+
+def run_tg_fetch(chat: str, mid: int) -> str:
+    """Run ``tg_client.py --fetch`` and return combined logs."""
+    env = os.environ.copy()
+    env.setdefault("LOG_LEVEL", "DEBUG")
+    if env.get("TEST_MODE") == "1":
+        return "TEST_MODE enabled, skipping Telegram fetch\n"
+    log_file = Path("errors.log")
+    if log_file.exists():
+        log_file.unlink()
+    proc = subprocess.run(
+        [sys.executable, "src/tg_client.py", "--fetch", chat, str(mid)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    output = proc.stdout
+    if log_file.exists():
+        output += "\n" + read_text(log_file)
+        log_file.unlink()
+    return output
+
+
+def collect_files(lot_id: str) -> list[tuple[str, str]]:
+    """Return ``[(name, content), ...]`` for files related to ``lot_id``."""
+    files: list[tuple[str, str]] = []
+    lot_file = LOTS_DIR / f"{lot_id}.json"
+    if lot_file.exists():
+        files.append((str(lot_file), read_text(lot_file)))
+        lot_data = load_json(lot_file)
+    else:
+        lot_data = None
+    vec = VEC_DIR / f"{lot_id}.json"
+    if vec.exists():
+        files.append((str(vec), read_text(vec)))
+    if not lot_data:
+        return files
+    lot = lot_data[0] if isinstance(lot_data, list) else lot_data
+    raw_rel = lot.get("source:path")
+    if raw_rel:
+        raw_path = RAW_DIR / raw_rel
+        files.append((str(raw_path), read_text(raw_path)))
+    for rel in lot.get("files", []):
+        p = MEDIA_DIR / rel
+        files.append((str(p), f"<binary {p.name}>") if p.exists() else (str(p), ""))
+        meta = p.with_suffix(".md")
+        if meta.exists():
+            files.append((str(meta), read_text(meta)))
+        cap = p.with_suffix(".caption.md")
+        if cap.exists():
+            files.append((str(cap), read_caption(cap)))
+    return files
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Dump debug info for a lot")
+    parser.add_argument("url", help="link to the lot page")
+    args = parser.parse_args(argv)
+
+    lot_id, _lang = parse_lot_id(args.url)
+    chat, mid = load_source_info(lot_id)
+    if not chat or not mid:
+        print("Failed to determine chat or message id", file=sys.stderr)
+        return
+
+    logs = run_tg_fetch(chat, mid)
+    parts = ["### tg_client log", logs.strip()]
+    for name, content in collect_files(lot_id):
+        parts.append(f"\n\n### {name}\n{content.strip()}")
+    print("\n".join(parts))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_debug_dump.py
+++ b/tests/test_debug_dump.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import debug_dump
+
+
+def test_parse_lot_id():
+    lot, lang = debug_dump.parse_lot_id(
+        "http://example.com/chat/2025/06/1234-0_ru.html"
+    )
+    assert lot == "chat/2025/06/1234-0"
+    assert lang == "ru"
+


### PR DESCRIPTION
## Summary
- add `debug_dump.py` for gathering logs and files around one lot
- document the new script
- integrate with Makefile and add a unit test

## Testing
- `make precommit`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jinja2'; ValueError in sklearn)*

------
https://chatgpt.com/codex/tasks/task_e_68581afc2aac8324a05c96f8e18a9531