### PR TITLE
Improve debug_dump fallback

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -212,7 +212,9 @@ Pass a page URL and the script will trim the hostname, run
 `tg_client.py --fetch` on the underlying Telegram post and then append
 the resulting logs along with the lot JSON, vector file and raw post.
 Captions and image metadata are included when present so the entire
-pipeline state can be shared in one go.
+pipeline state can be shared in one go. If the lot JSON is missing the
+chat name and message ID are extracted from the page path so Telegram
+can still be queried.
 
 ## Makefile
 The `Makefile` in the repository root wires these scripts together. Running

--- a/tests/test_debug_dump.py
+++ b/tests/test_debug_dump.py
@@ -13,3 +13,9 @@ def test_parse_lot_id():
     assert lot == "chat/2025/06/1234-0"
     assert lang == "ru"
 
+
+def test_guess_source_from_lot():
+    chat, mid = debug_dump.guess_source_from_lot("chat/2025/06/1234-0")
+    assert chat == "chat"
+    assert mid == 1234
+


### PR DESCRIPTION
## Summary
- update `debug_dump.py` to derive Telegram chat and message ID from URL when the lot JSON is missing
- document the new behaviour in `services.md`
- test `guess_source_from_lot` helper

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858234256a083249255fea20b562bf4