### PR TITLE
Fix debug file naming

### DIFF
--- a/src/lot_io.py
+++ b/src/lot_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 from datetime import datetime, timezone
+from pathlib import Path
 
 from log_utils import get_logger
 from serde_utils import load_json, write_json
@@ -85,4 +86,34 @@ def write_lots(path: Path, lots: Iterable[dict]) -> None:
         cleaned.append(_clean_lot(lot))
     write_json(path, cleaned)
     log.debug("Wrote lots", path=str(path))
+
+
+def make_lot_id(rel: Path, index: int) -> str:
+    """Return lot id string for ``rel`` and ``index``.
+
+    ``rel`` is the JSON file path relative to the ``data/lots`` directory
+    without the ``.json`` suffix.
+    """
+    return f"{rel.with_suffix('')}-{index}"
+
+
+def parse_lot_id(lot_id: str) -> tuple[Path, int]:
+    """Return ``(relative_path, index)`` extracted from ``lot_id``."""
+    p = Path(lot_id)
+    name = p.name
+    if '-' in name:
+        base, idx = name.rsplit('-', 1)
+    else:
+        base, idx = name, '0'
+    try:
+        index = int(idx)
+    except ValueError:
+        index = 0
+    return p.with_name(base), index
+
+
+def lot_json_path(lot_id: str, root: Path) -> Path:
+    """Return full JSON path for ``lot_id`` given ``root`` directory."""
+    rel, _ = parse_lot_id(lot_id)
+    return root / rel.with_suffix('.json')
 

--- a/tests/test_debug_dump.py
+++ b/tests/test_debug_dump.py
@@ -6,8 +6,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import debug_dump
 
 
-def test_parse_lot_id():
-    lot, lang = debug_dump.parse_lot_id(
+def test_parse_url():
+    lot, lang = debug_dump.parse_url(
         "http://example.com/chat/2025/06/1234-0_ru.html"
     )
     assert lot == "chat/2025/06/1234-0"

--- a/tests/test_lot_io_extra.py
+++ b/tests/test_lot_io_extra.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from lot_io import get_seller, get_timestamp
+from lot_io import make_lot_id, parse_lot_id
 
 
 def test_get_seller_priority():
@@ -27,3 +28,11 @@ def test_get_timestamp_parsing():
     assert get_timestamp(lot_past) is not None
     assert get_timestamp(lot_future) is None
     assert get_timestamp(lot_bad) is None
+
+
+def test_id_roundtrip():
+    rel = Path("chat/2025/06/1234")
+    lot_id = make_lot_id(rel, 2)
+    back_rel, idx = parse_lot_id(lot_id)
+    assert back_rel == rel
+    assert idx == 2


### PR DESCRIPTION
## Summary
- centralize lot id parsing helpers
- use them in debug dump to fetch correct file
- test roundtrip for lot IDs

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858267b0e5c83248d27b4ec1dbb3acb