### PR TITLE
Improve debug_dump logging

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -215,6 +215,8 @@ Captions and image metadata are included when present so the entire
 pipeline state can be shared in one go. If the lot JSON is missing the
 chat name and message ID are extracted from the page path so Telegram
 can still be queried.
+Standard error from the Telegram client is also captured so dependency
+issues are visible.
 
 ## Makefile
 The `Makefile` in the repository root wires these scripts together. Running

--- a/src/debug_dump.py
+++ b/src/debug_dump.py
@@ -98,6 +98,8 @@ def run_tg_fetch(chat: str, mid: int) -> str:
         text=True,
     )
     output = proc.stdout
+    if proc.stderr:
+        output += "\n" + proc.stderr
     if log_file.exists():
         output += "\n" + read_text(log_file)
         log_file.unlink()

--- a/tests/test_debug_dump.py
+++ b/tests/test_debug_dump.py
@@ -19,3 +19,20 @@ def test_guess_source_from_lot():
     assert chat == "chat"
     assert mid == 1234
 
+
+def test_run_tg_fetch_includes_stderr(tmp_path, monkeypatch):
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+    class DummyProc:
+        stdout = "out"
+        stderr = "err"
+
+    def dummy_run(*_a, **_k):
+        return DummyProc()
+
+    monkeypatch.setattr(debug_dump.subprocess, "run", dummy_run)
+    monkeypatch.chdir(tmp_path)
+    out = debug_dump.run_tg_fetch("chat", 1)
+    assert "out" in out
+    assert "err" in out
+


### PR DESCRIPTION
## Summary
- capture stderr from `tg_client.py` so debug dumps include error details
- document stderr capture in **services.md**
- test that `run_tg_fetch()` forwards stderr

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582bbcb35c8324bd1a5e79f22f0fc9