### PR TITLE
Improve raw post parsing

### DIFF
--- a/src/moderation.py
+++ b/src/moderation.py
@@ -84,10 +84,16 @@ def should_skip_message(meta: dict, text: str) -> bool:
         return True
     files: list[str] = []
     if "files" in meta:
+        val = meta.get("files")
         try:
-            files = ast.literal_eval(meta.get("files", "[]"))
+            if isinstance(val, str):
+                files = ast.literal_eval(val)
+            elif isinstance(val, list):
+                files = val
+            else:
+                raise ValueError("bad files type")
         except Exception:
-            log.debug("Bad file list", value=meta.get("files"), id=meta.get("id"))
+            log.debug("Bad file list", value=val, id=meta.get("id"))
     if not text.strip() and not files:
         log.debug("Message rejected", reason="empty", id=meta.get("id"))
         return True

--- a/src/post_io.py
+++ b/src/post_io.py
@@ -6,7 +6,24 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 from log_utils import get_logger
-from serde_utils import parse_md, write_md
+from serde_utils import parse_md, write_md, read_md
+import ast
+
+
+def _parse_block(text: str) -> tuple[dict[str, str], str]:
+    """Return metadata dict and remaining body from ``text``."""
+    lines = text.splitlines()
+    meta: dict[str, str] = {}
+    body_start = 0
+    for i, line in enumerate(lines):
+        if not line.strip():
+            body_start = i + 1
+            break
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip()
+    body = "\n".join(lines[body_start:])
+    return meta, body
 
 log = get_logger().bind(module=__name__)
 
@@ -50,11 +67,45 @@ def get_timestamp(meta: dict) -> datetime | None:
 
 def read_post(path: Path) -> tuple[dict[str, str], str]:
     """Return metadata dictionary and body text for ``path``."""
-    meta, text = parse_md(path)
+    text = read_md(path)
+    meta_all: list[dict[str, str]] = []
+    rest = text
+    while True:
+        meta, rest_body = _parse_block(rest)
+        if not meta:
+            break
+        meta_all.append(meta)
+        lines = rest_body.lstrip().splitlines()
+        if not lines:
+            rest = ""
+            break
+        first = lines[0]
+        key = first.split(":", 1)[0].strip() if ":" in first else ""
+        if key and key in meta:
+            rest = rest_body.lstrip()
+            continue
+        rest = rest_body
+        break
+
+    if not meta_all:
+        return {}, rest
+
+    meta = meta_all[0]
+    for extra in meta_all[1:]:
+        for k, v in extra.items():
+            if k == "files":
+                base = ast.literal_eval(meta.get("files", "[]")) if "files" in meta else []
+                add = ast.literal_eval(v) if isinstance(v, str) else v
+                merged = list(dict.fromkeys(base + add))
+                meta["files"] = str(merged)
+            else:
+                assert meta.get(k) == v, f"mismatched header {k} in {path}"
+
     for k, v in list(meta.items()):
         if isinstance(v, str) and v.isdigit():
             meta[k] = int(v)
-    return meta, text
+
+    return meta, rest.strip()
 
 
 def write_post(path: Path, meta: dict[str, str], body: str) -> None:
@@ -62,6 +113,12 @@ def write_post(path: Path, meta: dict[str, str], body: str) -> None:
     assert get_timestamp(meta) is not None, "date required"
     assert get_contact(meta) is not None, "contact required"
     meta_lines = [f"{k}: {v}" for k, v in meta.items() if v is not None]
+    lines = body.strip().splitlines()
+    if lines:
+        first = lines[0]
+        key = first.split(":", 1)[0].strip() if ":" in first else ""
+        if key and key in meta:
+            raise AssertionError("body contains duplicated headers")
     write_md(path, "\n".join(meta_lines) + "\n\n" + body.strip())
     log.debug("Wrote post", path=str(path))
 

--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -499,7 +499,10 @@ async def _save_message(
         or getattr(getattr(msg, "media", None), "caption", None)
         or getattr(msg, "message", "")
     )
+    log.debug("Raw message text", chat=chat, id=msg.id, preview=str(text)[:80])
     text = str(text).replace("View original post", "").strip()
+    log.debug("Processed message text", chat=chat, id=msg.id, preview=text[:80])
+    log.debug("Saving message", chat=chat, id=msg.id, files=len(files), preview=text[:80])
     group_path = None
     if msg.grouped_id and not replace:
         group_path = _GROUPS.get(msg.grouped_id) or _find_group_path(chat, msg.grouped_id)

--- a/tests/test_post_io_extra.py
+++ b/tests/test_post_io_extra.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from post_io import get_contact, get_timestamp
+from post_io import get_contact, get_timestamp, write_post, read_post
+import ast
+import pytest
 
 
 def test_get_contact_priority():
@@ -29,4 +31,37 @@ def test_get_timestamp_parsing():
     assert get_timestamp(meta_past) is not None
     assert get_timestamp(meta_future) is None
     assert get_timestamp(meta_bad) is None
+
+
+def test_write_post_rejects_header_in_body(tmp_path: Path):
+    path = tmp_path / "post.md"
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    meta = {"id": 1, "chat": "x", "date": now, "sender_name": "u"}
+    with pytest.raises(AssertionError):
+        write_post(path, meta, "id: 2\ntext")
+
+
+def test_read_post_merges_files(tmp_path: Path):
+    path = tmp_path / "post.md"
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    content = (
+        f"id: 1\nchat: x\ndate: {now}\nfiles: ['a.jpg']\n\n"
+        f"id: 1\nchat: x\ndate: {now}\nfiles: ['b.jpg']\n\nbody"
+    )
+    path.write_text(content)
+    meta, text = read_post(path)
+    assert ast.literal_eval(meta.get("files", "[]")) == ["a.jpg", "b.jpg"]
+    assert text == "body"
+
+
+def test_read_post_mismatch_raises(tmp_path: Path):
+    path = tmp_path / "post.md"
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    content = (
+        f"id: 1\nchat: x\ndate: {now}\n\n"
+        f"id: 2\nchat: x\ndate: {now}\n\n"
+    )
+    path.write_text(content)
+    with pytest.raises(AssertionError):
+        read_post(path)
 


### PR DESCRIPTION
## Summary
- merge duplicate metadata blocks when reading posts
- assert when body begins with metadata headers
- handle lists in moderation check
- log text extraction in Telegram client
- unit tests for new post_io features

## Testing
- `make precommit`
- `pytest tests/test_post_io_extra.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68582eb1b3cc83248130a261e69a2b97