### PR TITLE
fix(post_io): break duplicate header loop

### DIFF
--- a/src/post_io.py
+++ b/src/post_io.py
@@ -82,7 +82,12 @@ def read_post(path: Path) -> tuple[dict[str, str], str]:
         first = lines[0]
         key = first.split(":", 1)[0].strip() if ":" in first else ""
         if key and key in meta:
-            rest = rest_body.lstrip()
+            new_rest = rest_body.lstrip()
+            if new_rest == rest:
+                log.warning("Duplicate header loop", path=str(path))
+                rest = rest_body
+                break
+            rest = new_rest
             continue
         rest = rest_body
         break

--- a/src/serde_utils.py
+++ b/src/serde_utils.py
@@ -33,7 +33,9 @@ def write_md(path: str | Path, text: str) -> None:
     """Write ``text`` to ``path`` ensuring a trailing newline."""
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(text.rstrip() + "\n", encoding="utf-8")
+    if not text.endswith("\n"):
+        text += "\n"
+    p.write_text(text, encoding="utf-8")
     log.debug("Wrote markdown", path=str(p))
 
 


### PR DESCRIPTION
## Summary
- keep trailing blank line when writing Markdown
- detect duplicated headers when reading posts

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858462d6b908324b354e455636f23d1