### PR TITLE
fix(tg_client): clear skipped-media on forced fetch

### DIFF
--- a/src/tg_client.py
+++ b/src/tg_client.py
@@ -530,6 +530,8 @@ async def _save_message(
             )
         except Exception:
             log.warning("Invalid file list", path=str(path))
+        if force_media:
+            meta_prev.pop("skipped_media", None)
 
     files = []
     skipped_reason = None


### PR DESCRIPTION
## Summary
- avoid keeping skipped-media marker on forced media fetch

## Testing
- `make precommit`
- `TEST_MODE=1 PYTHONPATH=. make -B -j all` *(fails: ModuleNotFoundError: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_68585ecd2860832493de4a6585512950