### PR TITLE
fix(tg_client): always fetch media

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -48,10 +48,9 @@ Uses Telethon to mirror the target chats as a normal user account.
   Progress older than the current `KEEP_DAYS` window is ignored so lowering the
   threshold does not re-fetch deleted history. Attachments that fail to download
   are skipped with a warning and the reason is stored under `skipped_media` in
-  the message metadata. The client ignores videos (`.mp4`), audio files, images
-  larger than ten megabytes and any media attached to messages more than two
-  days old. The `--fetch` option overrides the age check so individual posts can
-  be reprocessed with all their files. Messages marked this way are ignored by
+  the message metadata. The client ignores videos (`.mp4`), audio files or images
+  larger than ten megabytes. The `--fetch` option can reprocess individual posts
+  with all their files. Messages marked this way are ignored by
   `chop.py` so only complete
   posts are parsed. When the media was downloaded previously the field is left
   out so older posts keep their files intact.

--- a/tests/test_tg_client.py
+++ b/tests/test_tg_client.py
@@ -545,7 +545,7 @@ def test_should_skip_media(monkeypatch):
     old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=3)
     file5 = types.SimpleNamespace(ext=".jpg", mime_type="image/jpeg", size=100)
     msg = types.SimpleNamespace(date=old, file=file5)
-    assert tg_client._should_skip_media(msg) == "old"
+    assert tg_client._should_skip_media(msg) is None
 
 
 def test_save_message_respects_skip(tmp_path, monkeypatch):
@@ -626,12 +626,12 @@ def test_save_message_skip_old_media(tmp_path, monkeypatch):
 
         await tg_client._save_message(client, "chat", msg)
 
-        assert called["d"] is False
+        assert called["d"] is True
         md_file = tmp_path / "chat" / f"{old_date:%Y}" / f"{old_date:%m}" / "1.md"
         assert md_file.exists()
         text = md_file.read_text()
-        assert "files" not in text
-        assert "skipped_media" in text
+        assert "files" in text
+        assert "skipped_media" not in text
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- remove MEDIA_MAX_AGE logic from `tg_client`
- keep existing media when reprocessing messages
- update docs to reflect new behaviour
- adjust tests for new media handling

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685874fe01bc8324a7660ee036e104b9