### PR TITLE
feat(pending_embed): log count of pending lots

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -129,6 +129,7 @@ refreshed. `pending_embed.py` upgrades any leftover single-object files by
 wrapping them in a list and deletes mismatched ones so stale vectors never pollute
 the index. Files from moderated posts are skipped entirely so no vectors are
 stored for spam.
+The script now logs how many lots need embeddings which helps spot empty runs.
 
 Vector ids are generated with `lot_io.make_lot_id` which keeps every
 subdirectory from `data/lots`.  This matches the ids used by

--- a/scripts/pending_embed.py
+++ b/scripts/pending_embed.py
@@ -61,9 +61,14 @@ def _needs_embed(path: Path, vec: Path, lots: list[dict]) -> bool:
 
 
 def main() -> None:
+    if not LOTS_DIR.exists():
+        log.error("LOTS_DIR missing", dir=str(LOTS_DIR))
+        return
+
     files = sorted(
         LOTS_DIR.rglob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True
     )
+    pending: list[Path] = []
     for path in files:
         lots = read_lots(path) or []
         if not lots:
@@ -86,8 +91,13 @@ def main() -> None:
             log.info("Skipping", file=str(path), reason="moderation")
             continue
         if _needs_embed(path, out, lots):
-            sys.stdout.write(str(path))
-            sys.stdout.write("\0")
+            pending.append(path)
+
+    for path in pending:
+        sys.stdout.write(str(path))
+        sys.stdout.write("\0")
+
+    log.info("Pending lots", count=len(pending))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log when `data/lots` directory is missing
- collect pending paths and emit a count to logs
- document pending embed count in `docs/services.md`

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588a5245d48324bd64a4567ed49f32