### PR TITLE
feat(embed): log moderation reason

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -133,7 +133,10 @@ the index. Files from moderated posts are skipped entirely so no vectors are
 stored for spam.
 The script now logs how many lots need embeddings which helps spot empty runs.
 If a raw message cannot be parsed the error is logged and the lot is still
-queued so embeddings are never skipped due to metadata issues.
+queued so embeddings are never skipped due to metadata issues. When a lot is
+skipped the log records the exact rule that triggered so confusing drops are
+easier to debug. Output is flushed after every file path so GNU Parallel can
+start embedding jobs right away.
 
 Vector ids are generated with `lot_io.make_lot_id` which keeps every
 subdirectory from `data/lots`.  This matches the ids used by

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -71,17 +71,14 @@ def should_skip_user(username: str | None) -> bool:
     return username.lower() in BLACKLISTED_USERS
 
 
-def should_skip_message(meta: dict, text: str) -> bool:
-    """Return ``True`` when the raw Telegram message should be ignored."""
+def message_skip_reason(meta: dict, text: str) -> str | None:
+    """Return the moderation reason for ``meta`` and ``text`` or ``None``."""
     if meta.get("skipped_media"):
-        log.debug("Message rejected", reason="skipped-media", id=meta.get("id"))
-        return True
+        return "skipped-media"
     if should_skip_user(meta.get("sender_username")):
-        log.debug("Message rejected", reason="blacklisted-user", user=meta.get("sender_username"))
-        return True
+        return "blacklisted-user"
     if should_skip_text(text):
-        log.debug("Message rejected", id=meta.get("id"))
-        return True
+        return "banned-text"
     files: list[str] = []
     if "files" in meta:
         val = meta.get("files")
@@ -95,21 +92,35 @@ def should_skip_message(meta: dict, text: str) -> bool:
         except Exception:
             log.debug("Bad file list", value=val, id=meta.get("id"))
     if not text.strip() and not files:
-        log.debug("Message rejected", reason="empty", id=meta.get("id"))
+        return "empty"
+    return None
+
+
+def should_skip_message(meta: dict, text: str) -> bool:
+    """Return ``True`` when the raw Telegram message should be ignored."""
+    reason = message_skip_reason(meta, text)
+    if reason:
+        log.debug("Message rejected", reason=reason, id=meta.get("id"))
         return True
     return False
 
 
+def lot_skip_reason(lot: dict) -> str | None:
+    """Return the moderation reason for ``lot`` or ``None``."""
+    if lot.get("fraud") is not None:
+        return "fraud"
+    if lot.get("contact:telegram") == "@username":
+        return "example contact"
+    if any(not lot.get(f) for f in REVIEW_FIELDS):
+        return "missing translation"
+    return None
+
+
 def should_skip_lot(lot: dict) -> bool:
     """Return ``True`` when the lot fails additional checks."""
-    if lot.get("fraud") is not None:
-        log.debug("Lot rejected", reason="fraud", id=lot.get("_id"))
-        return True
-    if lot.get("contact:telegram") == "@username":
-        log.debug("Lot rejected", reason="example contact")
-        return True
-    if any(not lot.get(f) for f in REVIEW_FIELDS):
-        log.debug("Lot rejected", reason="missing translation", id=lot.get("_id"))
+    reason = lot_skip_reason(lot)
+    if reason:
+        log.debug("Lot rejected", reason=reason, id=lot.get("_id"))
         return True
     return False
 


### PR DESCRIPTION
## Summary
- record which moderation rule failed in `pending_embed.py`
- flush output for GNU Parallel
- expose helper functions in `moderation`
- document new logging and flushing

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685898839b0483249bbb990ddd0bdb1b