### PR TITLE
feat(lot_io): validate translations before saving lots

### DIFF
--- a/docs/ontology_housekeeping.md
+++ b/docs/ontology_housekeeping.md
@@ -54,8 +54,11 @@ resolved remove the entries and regenerate the file.
 ## Titles and Descriptions
 
 The chopper generates `title_<lang>` and `description_<lang>` for every lot.
-They should summarise the offer clearly. Popular boilerplate titles or
-descriptions that do not distinguish one ad from another should be
+Every language version must be present. The lot serializer rejects JSON
+files missing any of them and the cleanup step drops such entries so the
+parser can try again.
+Titles and descriptions should summarise the offer clearly. Popular
+boilerplate text that does not distinguish one ad from another should be
 explicitly discouraged in the prompt so the resulting website lists are
 useful.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -11,7 +11,10 @@ Missing captions mean the chopper cannot pair pictures with their text.
 ## Lots
 
 All message Markdown files under `data/raw` should have a JSON lot file in
-`data/lots`. Without it the embedder will skip the message.
+`data/lots`. Without it the embedder will skip the message. Every lot must
+include translated titles and descriptions for each language. Missing
+translations are treated as an error and the cleanup step removes such files
+so the parser can try again.
 
 ## Vectors
 

--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from config_utils import load_config
 from log_utils import get_logger, install_excepthook
-from lot_io import read_lots
+from lot_io import read_lots, TRANSLATION_FIELDS
 
 log = get_logger().bind(script=__file__)
 install_excepthook(log)
@@ -76,6 +76,11 @@ def _clean_lots() -> None:
         items = read_lots(path)
         if not items:
             log.warning("Bad lot file", file=str(path))
+            continue
+        if any(not lot.get(f) for lot in items for f in TRANSLATION_FIELDS):
+            path.unlink()
+            log.info("Deleted lot", file=str(path), reason="missing translations")
+            count += 1
             continue
         src = items[0].get("source:path")
         if src and not (RAW_DIR / src).exists():

--- a/src/lot_io.py
+++ b/src/lot_io.py
@@ -31,6 +31,16 @@ SELLER_FIELDS = [
     "seller",
 ]
 
+# ``title_<lang>`` and ``description_<lang>`` must be present for every lot.
+TRANSLATION_FIELDS = [
+    "title_en",
+    "description_en",
+    "title_ru",
+    "description_ru",
+    "title_ka",
+    "description_ka",
+]
+
 
 def get_seller(lot: dict) -> str | None:
     """Return the seller identifier or ``None`` when missing."""
@@ -85,6 +95,8 @@ def write_lots(path: Path, lots: Iterable[dict]) -> None:
     for lot in lots:
         assert get_timestamp(lot) is not None, "timestamp required"
         assert get_seller(lot) is not None, "seller required"
+        missing = [f for f in TRANSLATION_FIELDS if not lot.get(f)]
+        assert not missing, f"missing translations: {', '.join(missing)}"
         cleaned.append(_clean_lot(lot))
     write_json(path, cleaned)
     log.debug("Wrote lots", path=str(path))

--- a/tests/test_clean_data.py
+++ b/tests/test_clean_data.py
@@ -57,14 +57,53 @@ def test_clean_data(tmp_path, monkeypatch):
     lot_dir = clean_data.LOTS_DIR / "chat" / "2024" / "05"
     lot_dir.mkdir(parents=True)
     old_lot = lot_dir / "1.json"
-    old_lot.write_text(json.dumps([{"_id": "1", "source:path": "chat/2024/05/1.md"}]))
+    old_lot.write_text(
+        json.dumps([
+            {
+                "_id": "1",
+                "source:path": "chat/2024/05/1.md",
+                "title_en": "t",
+                "description_en": "d",
+                "title_ru": "t",
+                "description_ru": "d",
+                "title_ka": "t",
+                "description_ka": "d",
+            }
+        ])
+    )
     new_lot = lot_dir / "2.json"
-    new_lot.write_text(json.dumps([{"_id": "2", "source:path": "chat/2024/05/2.md"}]))
+    new_lot.write_text(
+        json.dumps([
+            {
+                "_id": "2",
+                "source:path": "chat/2024/05/2.md",
+                "title_en": "t",
+                "description_en": "d",
+                "title_ru": "t",
+                "description_ru": "d",
+                "title_ka": "t",
+                "description_ka": "d",
+            }
+        ])
+    )
 
     lot_empty_dir = clean_data.LOTS_DIR / "oldchat" / "2024" / "05"
     lot_empty_dir.mkdir(parents=True)
     empty_lot = lot_empty_dir / "3.json"
-    empty_lot.write_text(json.dumps([{"_id": "3", "source:path": "oldchat/2024/05/1.md"}]))
+    empty_lot.write_text(
+        json.dumps([
+            {
+                "_id": "3",
+                "source:path": "oldchat/2024/05/1.md",
+                "title_en": "t",
+                "description_en": "d",
+                "title_ru": "t",
+                "description_ru": "d",
+                "title_ka": "t",
+                "description_ka": "d",
+            }
+        ])
+    )
 
     vec_dir = clean_data.VEC_DIR / "chat" / "2024" / "05"
     vec_dir.mkdir(parents=True)
@@ -93,3 +132,20 @@ def test_clean_data(tmp_path, monkeypatch):
     assert v_new.exists()
     assert not v_orphan.exists()
     assert not orphan_dir.exists()
+
+
+def test_clean_data_removes_missing_translations(tmp_path, monkeypatch):
+    monkeypatch.setattr(clean_data, "RAW_DIR", tmp_path / "raw")
+    monkeypatch.setattr(clean_data, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(clean_data, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(clean_data, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(clean_data, "load_config", lambda: DummyCfg())
+
+    lot_dir = clean_data.LOTS_DIR / "chat" / "2024" / "05"
+    lot_dir.mkdir(parents=True)
+    bad = lot_dir / "1.json"
+    bad.write_text(json.dumps([{"_id": "1"}]))
+
+    clean_data.main()
+
+    assert not bad.exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import sys
 from datetime import datetime, timezone
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -43,8 +44,43 @@ def test_caption_roundtrip(tmp_path: Path):
 def test_lot_roundtrip(tmp_path: Path):
     path = tmp_path / "lot.json"
     now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-    lots = [{"a": 1, "b": "x", "c": "", "timestamp": now, "contact:phone": "1"}]
+    lots = [
+        {
+            "a": 1,
+            "b": "x",
+            "c": "",
+            "timestamp": now,
+            "contact:phone": "1",
+            "title_en": "t",
+            "description_en": "d",
+            "title_ru": "t",
+            "description_ru": "d",
+            "title_ka": "t",
+            "description_ka": "d",
+        }
+    ]
     write_lots(path, lots)
     data = read_lots(path)
-    assert data == [{"a": 1, "b": "x", "timestamp": now, "contact:phone": "1"}]
+    assert data == [
+        {
+            "a": 1,
+            "b": "x",
+            "timestamp": now,
+            "contact:phone": "1",
+            "title_en": "t",
+            "description_en": "d",
+            "title_ru": "t",
+            "description_ru": "d",
+            "title_ka": "t",
+            "description_ka": "d",
+        }
+    ]
+
+
+def test_write_lots_requires_translations(tmp_path: Path):
+    path = tmp_path / "lot.json"
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    lots = [{"timestamp": now, "contact:phone": "1", "title_en": "t"}]
+    with pytest.raises(AssertionError):
+        write_lots(path, lots)
 


### PR DESCRIPTION
## Summary
- require translated titles & descriptions in `write_lots`
- drop lots with missing translations during cleanup
- update docs on translation requirements
- test missing translations handling

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589cded540832496b791dae6af83e2