### PR TITLE
feat(site): drop lots without embeddings

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -153,7 +153,9 @@ from `data/lots` and written to `data/views`.  The script loads
 `ontology/fields.json` to order attribute tables and embeddings from `data/vectors` to suggest
 similar lots.  Vector files without a matching lot are dropped before computing
 similarity so stale data never bloats memory. Similarity search now uses `scikit-learn` to find nearest
-neighbours efficiently. Each lot page shows images in a small carousel,
+neighbours efficiently. Lots without vectors are skipped entirely during rendering.
+Embedding arrays are written as compact JSON with each number using no more than seven characters and no spaces.
+Each lot page shows images in a small carousel,
 scaled to at most 40% of the viewport height, a table of
 all recognised fields and a link back to the Telegram post.  Pages are
 generated separately for every language configured in `config.py`.  The

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -20,6 +20,8 @@ so the parser can try again.
 
 Every lot JSON is expected to have an embedding stored in `data/vectors`.
 A vector older than its source lot is treated as stale and reported.
+Pages are not generated for lots missing embeddings so incomplete data never
+reaches the website.
 
 Earlier versions used a dedicated ``validate_outputs.py`` helper.
 The checks are now built into the main pipeline stages so no additional commands are needed.

--- a/templates/category.html
+++ b/templates/category.html
@@ -20,7 +20,7 @@
   </thead>
   <tbody>
   {% for lot in items %}
-    <tr data-id="{{ lot.id }}" data-vector='{{ lot.vec | tojson }}' data-price="{{ lot.price or '' }}">
+    <tr data-id="{{ lot.id }}" data-vector='{{ lot.vec | default("null") | safe }}' data-price="{{ lot.price or '' }}'>
       <td><a href="{{ lot.link }}">{{ lot.title }}</a></td>
       <td>{{ lot.price or '' }}</td>
       <td>{{ lot.seller or '' }}</td>

--- a/templates/lot.html
+++ b/templates/lot.html
@@ -30,7 +30,7 @@
 <script>
   window.currentLot = {
     id: {{ lot['_id']|tojson }},
-    vector: {{ vector|tojson }}
+    vector: {{ vector|default("null")|safe }}
   };
 </script>
 <h2>{{ _('Similar items') }}</h2>


### PR DESCRIPTION
## Summary
- skip lots missing vectors when rendering site
- add `_format_vector` helper to compact embeddings
- keep vectors compact when rendering lot/category pages
- document skipping lots without vectors and compact format
- update tests for new behaviour

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a0ebcc188324b3d1849bef0af912