### PR TITLE
feat(site): improve sorting and layout

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -171,8 +171,8 @@ timestamp that lies in the future it is ignored during rendering so the website
 never displays misleading dates.
 Each lot page also exposes "Like" and "Dislike" buttons. Votes are stored in the
 browser together with the lot embedding. Category pages offer a sorting switch
-that orders lots by price, by how similar they are to liked or disliked items or
-pushes unexplored offers to the top.
+that orders lots by price, by whether they are closer to liked or disliked
+items and then by distance, or pushes unexplored offers to the top.
 
 ## alert_bot.py
 Simple Telegram bot that lets users subscribe to notifications.  Alerts are sent

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -525,7 +525,7 @@ def main() -> None:
             )
             log.debug("Wrote", path=str(out))
 
-    recent.sort(key=lambda x: x.get("dt") or now, reverse=True)
+    recent.sort(key=lambda x: x.get("dt") or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
 
     log.debug("Writing index pages")
     index_tpls = {lang: envs[lang].get_template("index.html") for lang in langs}

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -1,8 +1,7 @@
 body {
   font-family: sans-serif;
-  margin: 0 auto;
+  margin: 0;
   padding: 1em;
-  max-width: 800px;
 }
 nav.top { display: flex; justify-content: space-between; margin-bottom: 1em; }
 .lang-switch a { margin-left: 0.5em; }


### PR DESCRIPTION
## Summary
- ensure tables stretch across the screen
- handle missing values when sorting
- refine relevance sort to prioritize like/dislike proximity
- push lots without timestamps to the end of lists

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a7c798e08324bae164dc3a9e2cdc