### PR TITLE
fix(scan_ontology): avoid overwriting excepthook

### DIFF
--- a/src/scan_ontology.py
+++ b/src/scan_ontology.py
@@ -16,7 +16,6 @@ from serde_utils import write_json
 from lot_io import read_lots
 
 log = get_logger().bind(script=__file__)
-install_excepthook(log)
 
 LOTS_DIR = Path("data/lots")
 RAW_DIR = Path("data/raw")
@@ -153,6 +152,7 @@ def collect_ontology() -> tuple[
 
 
 def main() -> None:
+    install_excepthook(log)
     log.info("Scanning ontology", path=str(LOTS_DIR))
     if not LOTS_DIR.exists() or not any(LOTS_DIR.rglob("*.json")):
         log.warning("Lots directory missing or empty", path=str(LOTS_DIR))
@@ -195,3 +195,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_scan_ontology_import.py
+++ b/tests/test_scan_ontology_import.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_import_does_not_install_excepthook(monkeypatch):
+    monkeypatch.setattr(sys, "excepthook", sys.__excepthook__)
+    if "scan_ontology" in sys.modules:
+        del sys.modules["scan_ontology"]
+    importlib.import_module("scan_ontology")
+    assert sys.excepthook is sys.__excepthook__
+


### PR DESCRIPTION
## Summary
- avoid installing the global excepthook when `scan_ontology` is imported
- add regression test

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b39336f88324a4238f4be386d9f5