### PR TITLE
feat(captions): store translated captions in JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ removed: pull ## Drop local posts removed from Telegram and tidy leftover files.
 	python src/tg_client.py --refetch --check-deleted
 	$(MAKE) clean # remove newly created leftovers
 
-caption: pull ## Generate image captions for files missing ``*.caption.md``.
+caption: pull ## Generate image captions for files missing ``*.caption.json``.
 	python scripts/pending_caption.py | parallel --eta -j16 -0 python src/caption.py
 
 chop: pull caption ## Split messages into lots using captions and message text.

--- a/docs/services.md
+++ b/docs/services.md
@@ -86,8 +86,8 @@ is stored, or if a stored file is missing its caption, so downloads continue in
 parallel. Before sending to the API every picture is scaled so the shorter side
 equals 512&nbsp;px, then ImageMagick's liquid rescale squeezes it down to
 ``512x512`` without cropping.
-Each processed image gets a companion `*.caption.md` file stored beside the
-original. Captions are later included in the lot chopper prompt where the
+Each processed image gets a companion `*.caption.json` file stored beside the
+original. Captions list `caption_<lang>` fields for all languages and are later included in the lot chopper prompt where the
 `chop.py` script lists every `Image <filename>` before its caption. This makes
 it crystal clear which picture the text belongs to. When `LOG_LEVEL` is set to
 `INFO`, the script logs each processed filename along with the generated

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -5,7 +5,8 @@ Each script checks for missing pieces and exits with an error when something is 
 
 ## Captions
 
-Each image stored under `data/media` must have a matching `*.caption.md` file.
+Each image stored under `data/media` must have a matching `*.caption.json` file.
+Captions include `caption_<lang>` keys for every language listed in `LANGS`.
 Missing captions mean the chopper cannot pair pictures with their text.
 
 ## Lots

--- a/scripts/pending_caption.py
+++ b/scripts/pending_caption.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from post_io import read_post
 from image_io import read_image_meta
+from caption_io import has_caption
 from moderation import should_skip_message
 from log_utils import get_logger
 
@@ -28,12 +29,16 @@ def _get_message_path(chat: str, msg_id: int) -> Path | None:
 
 def main() -> None:
     files = sorted(
-        (p for p in MEDIA_DIR.rglob("*") if p.is_file() and p.suffix != ".md"),
+        (
+            p
+            for p in MEDIA_DIR.rglob("*")
+            if p.is_file() and p.suffix not in {".md", ".json"}
+        ),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
     for path in files:
-        if path.with_suffix(".caption.md").exists():
+        if has_caption(path):
             continue
         meta = read_image_meta(path)
         chat = path.relative_to(MEDIA_DIR).parts[0]

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -30,6 +30,7 @@ from config_utils import load_config
 from log_utils import get_logger, install_excepthook
 from moderation import should_skip_message, should_skip_lot
 from post_io import read_post, raw_post_path, RAW_DIR
+from caption_io import read_caption
 
 log = get_logger().bind(script=__file__)
 install_excepthook(log)
@@ -145,7 +146,7 @@ def _iter_lots() -> list[dict]:
             meta: dict[str, str] | None = None
             text = ""
             if src:
-                raw_path = raw_post_path(src)
+                raw_path = raw_post_path(src, RAW_DIR)
                 meta, text = read_post(raw_path)
                 if should_skip_message(meta, text):
                     log.info(
@@ -198,8 +199,7 @@ def build_page(
         images = []
         for rel in lot.get("files", []):
             p = MEDIA_DIR / rel
-            cap = p.with_suffix(".caption.md")
-            caption = cap.read_text(encoding="utf-8") if cap.exists() else ""
+            caption = read_caption(p, lang)
             images.append({"path": rel, "caption": caption})
 
         # Drop internal helper fields that are meaningless to end users.
@@ -227,7 +227,7 @@ def build_page(
         orig_text = ""
         src = lot.get("source:path")
         if src:
-            _, orig_text = read_post(raw_post_path(src))
+            _, orig_text = read_post(raw_post_path(src, RAW_DIR))
 
         chat = lot.get("source:chat")
         mid = lot.get("source:message_id")

--- a/src/caption.py
+++ b/src/caption.py
@@ -14,7 +14,7 @@ from config_utils import load_config
 cfg = load_config()
 OPENAI_KEY = cfg.OPENAI_KEY
 from log_utils import get_logger, install_excepthook
-from caption_io import write_caption
+from caption_io import write_caption, has_caption
 from token_utils import estimate_tokens
 
 log = get_logger().bind(script=__file__)
@@ -78,11 +78,10 @@ def _guess_chat(path: Path) -> str:
 
 
 def caption_file(path: Path) -> str:
-    """Caption ``path`` with GPT-4o and save ``.caption.md`` beside it."""
+    """Caption ``path`` with GPT-4o and save ``.caption.json`` beside it."""
     orig = path.read_bytes()
     sha = hashlib.sha256(orig).hexdigest()
-    out = path.with_suffix(".caption.md")
-    if out.exists():
+    if has_caption(path):
         # Log at info level so users know the file was intentionally skipped.
         log.info("Caption exists", file=str(path))
         return sha
@@ -113,7 +112,7 @@ def caption_file(path: Path) -> str:
         log.exception("Caption failed", sha=sha)
         return sha
 
-    write_caption(out, text)
+    write_caption(path, text)
     log.info("Caption", file=str(path), text=text)
     return sha
 

--- a/src/caption_io.py
+++ b/src/caption_io.py
@@ -1,20 +1,70 @@
-"""Handle caption files stored beside images."""
+"""Helpers for translated caption files stored beside images."""
 
 from pathlib import Path
 
-from serde_utils import read_md, write_md
+from config_utils import load_config
+from serde_utils import read_md, load_json, write_json
 from log_utils import get_logger
+
+_LANGS: list[str] | None = None
+
+CAPTION_SUFFIX = ".caption.json"
+LEGACY_SUFFIX = ".caption.md"
 
 log = get_logger().bind(module=__name__)
 
 
-def read_caption(path: Path) -> str:
-    """Return caption text or empty string if missing."""
-    return read_md(path)
+def _get_langs() -> list[str]:
+    """Return configured languages, caching the result."""
+    global _LANGS
+    if _LANGS is None:
+        cfg = load_config()
+        _LANGS = getattr(cfg, "LANGS", ["en"])
+    return _LANGS
 
 
-def write_caption(path: Path, text: str) -> None:
-    """Write ``text`` to ``path`` with a trailing newline."""
-    write_md(path, text)
+def caption_json_path(image: Path) -> Path:
+    """Return new-style caption path for ``image``."""
+    return image.with_suffix(CAPTION_SUFFIX)
+
+
+def caption_md_path(image: Path) -> Path:
+    """Return legacy Markdown caption path for ``image``."""
+    return image.with_suffix(LEGACY_SUFFIX)
+
+
+def has_caption(image: Path) -> bool:
+    """Return ``True`` when any caption exists for ``image``."""
+    return caption_json_path(image).exists() or caption_md_path(image).exists()
+
+
+def read_caption(image: Path, lang: str | None = None) -> str:
+    """Return caption for ``image`` in ``lang`` or empty string when missing."""
+    langs = _get_langs()
+    lang = lang or langs[0]
+    json_path = caption_json_path(image)
+    if json_path.exists():
+        data = load_json(json_path)
+        if isinstance(data, dict):
+            key = f"caption_{lang}"
+            text = data.get(key, "")
+            if text and not text.endswith("\n"):
+                text += "\n"
+            return text
+    return read_md(caption_md_path(image))
+
+
+def write_caption(image: Path, text: str, lang: str | None = None) -> None:
+    """Write ``text`` as ``lang`` caption for ``image``."""
+    langs = _get_langs()
+    lang = lang or langs[0]
+    path = caption_json_path(image)
+    data = {f"caption_{l}": "" for l in langs}
+    if path.exists():
+        prev = load_json(path)
+        if isinstance(prev, dict):
+            data.update(prev)
+    data[f"caption_{lang}"] = text
+    write_json(path, data)
     log.debug("Wrote caption", path=str(path))
 

--- a/src/chop.py
+++ b/src/chop.py
@@ -18,7 +18,7 @@ cfg = load_config()
 OPENAI_KEY = cfg.OPENAI_KEY
 LANGS = cfg.LANGS
 from log_utils import get_logger, install_excepthook
-from caption_io import read_caption
+from caption_io import read_caption, has_caption
 from post_io import read_post, raw_post_path, RAW_DIR
 from message_utils import build_prompt
 import embed
@@ -71,11 +71,10 @@ def process_message(msg_path: Path) -> None:
             log.info("Skipping message", path=str(msg_path), reason="missing-media", file=str(p))
             return
         if p.suffix.lower() in IMAGE_EXTS:
-            cap = p.with_suffix(".caption.md")
-            if not cap.exists():
+            if not has_caption(p):
                 log.info("Skipping message", path=str(msg_path), reason="missing-caption", file=str(p))
                 return
-            caption_text = read_caption(cap)
+            caption_text = read_caption(p)
             log.debug("Found caption", file=str(p), text=caption_text)
             captions.append(caption_text)
 

--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -11,6 +11,7 @@ from config_utils import load_config
 from log_utils import get_logger, install_excepthook
 from lot_io import read_lots, TRANSLATION_FIELDS
 from post_io import raw_post_path, RAW_DIR
+from caption_io import has_caption
 
 log = get_logger().bind(script=__file__)
 install_excepthook(log)
@@ -39,7 +40,7 @@ def _clean_raw(cutoff: datetime) -> None:
     count = 0
     if not RAW_DIR.exists():
         return
-    for md in raw_post_path(Path()).rglob("*.md"):
+    for md in raw_post_path(Path(), RAW_DIR).rglob("*.md"):
         ts = _parse_date(md)
         if ts and ts < cutoff:
             md.unlink()
@@ -57,8 +58,7 @@ def _clean_media(cutoff: datetime) -> None:
         ts = _parse_date(md)
         if ts and ts < cutoff:
             file = md.with_suffix("")
-            caption = file.with_suffix(".caption.md")
-            if not caption.exists():
+            if not has_caption(file):
                 for p in [file, md]:
                     if p.exists():
                         p.unlink()
@@ -83,7 +83,7 @@ def _clean_lots() -> None:
             count += 1
             continue
         src = items[0].get("source:path")
-        if src and not raw_post_path(src).exists():
+        if src and not raw_post_path(src, RAW_DIR).exists():
             path.unlink()
             log.info("Deleted lot", file=str(path))
             count += 1

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -30,7 +30,7 @@ def gather_chop_input(msg_path: Path, media_dir: Path) -> str:
     files = ast.literal_eval(meta.get("files", "[]")) if "files" in meta else []
     captions = []
     for rel in files:
-        cap_path = (media_dir / rel).with_suffix(".caption.md")
+        cap_path = media_dir / rel
         caption_text = read_caption(cap_path)
         captions.append(caption_text)
     prompt = build_prompt(text, files, captions)

--- a/src/scan_ontology.py
+++ b/src/scan_ontology.py
@@ -114,12 +114,12 @@ def collect_ontology() -> tuple[
             src = lot.get("source:path")
             meta = None
             if src and has_raw:
-                meta, _ = read_post(raw_post_path(src))
+                meta, _ = read_post(raw_post_path(src, RAW_DIR))
             if _is_misparsed(lot, meta):
                 prompt = ""
                 if src and has_raw:
                     try:
-                        prompt = gather_chop_input(raw_post_path(src), MEDIA_DIR)
+                        prompt = gather_chop_input(raw_post_path(src, RAW_DIR), MEDIA_DIR)
                     except Exception:
                         log.exception("Failed to build parser input", source=src)
                 misparsed.append({"lot": lot, "input": prompt})
@@ -127,13 +127,13 @@ def collect_ontology() -> tuple[
                 prompt = ""
                 if src and has_raw:
                     try:
-                        prompt = gather_chop_input(raw_post_path(src), MEDIA_DIR)
+                        prompt = gather_chop_input(raw_post_path(src, RAW_DIR), MEDIA_DIR)
                     except Exception:
                         log.exception("Failed to build parser input", source=src)
                 fraud.append({"lot": lot, "input": prompt})
             if src and has_raw:
                 if meta is None:
-                    meta, _ = read_post(raw_post_path(src))
+                    meta, _ = read_post(raw_post_path(src, RAW_DIR))
                 if not meta.get("id") or not meta.get("chat") or not meta.get("date"):
                     chat = lot.get("source:chat") or meta.get("chat")
                     mid = lot.get("source:message_id") or meta.get("id")

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import os
 import sys
+import json
 import types
 
 # Provide a minimal ``openai`` stub before importing the module under test.
@@ -36,9 +37,10 @@ def test_caption_file_writes(tmp_path, monkeypatch):
     img.write_bytes(b"data")
 
     caption.caption_file(img)
-    out = img.with_suffix(".caption.md")
+    out = img.with_suffix(".caption.json")
     assert out.exists()
-    assert out.read_text().strip() == "desc"
+    data = json.loads(out.read_text())
+    assert data["caption_en"].strip() == "desc"
 
 
 def test_caption_logs(tmp_path, monkeypatch):

--- a/tests/test_clean_data.py
+++ b/tests/test_clean_data.py
@@ -46,7 +46,7 @@ def test_clean_data(tmp_path, monkeypatch):
     img_new = media_dir / "b.jpg"
     img_new.write_bytes(b"img2")
     (media_dir / "b.jpg.md").write_text(f"message_id:2\ndate:{recent.isoformat()}\n")
-    (media_dir / "b.caption.md").write_text("cap")
+    (media_dir / "b.caption.json").write_text('{"caption_en": "cap"}')
 
     media_empty_dir = clean_data.MEDIA_DIR / "oldchat" / "2024" / "05"
     media_empty_dir.mkdir(parents=True)

--- a/tests/test_debug_dump.py
+++ b/tests/test_debug_dump.py
@@ -71,8 +71,8 @@ def test_delete_files(tmp_path, monkeypatch):
     img.write_text("bin")
     img_md = img.with_suffix(".md")
     img_md.write_text("meta")
-    img_cap = img.with_suffix(".caption.md")
-    img_cap.write_text("cap")
+    img_cap = img.with_suffix(".caption.json")
+    img_cap.write_text('{"caption_en": "cap"}')
 
     debug_dump.delete_files(lot_id)
 

--- a/tests/test_pending_caption.py
+++ b/tests/test_pending_caption.py
@@ -27,7 +27,7 @@ def test_skip_existing(tmp_path, monkeypatch, capsys):
     img = pending_caption.MEDIA_DIR / "chat" / "2024" / "05" / "img.jpg"
     img.parent.mkdir(parents=True)
     img.write_bytes(b"img")
-    (img.with_suffix(".caption.md")).write_text("cap")
+    (img.with_suffix(".caption.json")).write_text("{\"caption_en\": \"cap\"}")
 
     pending_caption.main()
     out = capsys.readouterr().out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,7 +36,7 @@ def test_post_roundtrip(tmp_path: Path):
 
 
 def test_caption_roundtrip(tmp_path: Path):
-    path = tmp_path / "cap.md"
+    path = tmp_path / "cap.jpg"
     write_caption(path, "cap")
     assert read_caption(path) == "cap\n"
 


### PR DESCRIPTION
## Summary
- handle translated caption files in `caption_io`
- update captioning code to use JSON captions
- adjust media cleanup, chopping and build logic to new caption handling
- skip caption JSON files in `pending_caption.py`
- refresh documentation for caption JSON workflow
- update tests for the new caption format
- fix path handling with RAW_DIR throughout the codebase

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f9792a488324b1ecc95bb71d83d1