### PR TITLE
fix: adjust tests for structured outputs

### DIFF
--- a/src/caption.py
+++ b/src/caption.py
@@ -123,7 +123,10 @@ def caption_file(path: Path) -> str:
                 "json_schema": {"schema": schema, "name": "describe_image", "strict": True},
             },
         )
-        raw = resp.choices[0].message.content
+        msg = resp.choices[0].message
+        raw = getattr(msg, "content", None)
+        if raw is None and getattr(msg, "tool_calls", None):
+            raw = msg.tool_calls[0].function.arguments
         log.info("OpenAI response", text=raw, file=str(path))
         data = json.loads(raw)
     except Exception:

--- a/src/chop.py
+++ b/src/chop.py
@@ -126,7 +126,10 @@ def process_message(msg_path: Path) -> None:
                 "json_schema": {"schema": schema, "name": "extract_lots", "strict": True},
             },
         )
-        raw = resp.choices[0].message.content
+        msg = resp.choices[0].message
+        raw = getattr(msg, "content", None)
+        if raw is None and getattr(msg, "tool_calls", None):
+            raw = msg.tool_calls[0].function.arguments
         log.info("OpenAI response", text=raw)
         lots = json.loads(raw)
     except Exception:

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -28,11 +28,7 @@ def test_caption_file_writes(tmp_path, monkeypatch):
         choices=[
             types.SimpleNamespace(
                 message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments='{"caption_en": "desc"}')
-                        )
-                    ]
+                    content='{"caption_en": "desc"}'
                 )
             )
         ]
@@ -60,13 +56,7 @@ def test_caption_logs(tmp_path, monkeypatch):
     dummy_resp = types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
-                message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments='{"caption_en": "desc"}')
-                        )
-                    ]
-                )
+                message=types.SimpleNamespace(content='{"caption_en": "desc"}')
             )
         ]
     )

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -23,13 +23,7 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     dummy_resp = types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
-                message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments="[]")
-                        )
-                    ]
-                )
+                message=types.SimpleNamespace(content="[]")
             )
         ]
     )
@@ -49,21 +43,14 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     chop.main([str(msg)])
 
     assert (tmp_path / "lots" / "chat" / "2024" / "05" / "1.json").exists()
-    assert called.get("tool_choice") == "extract_lots"
-    assert isinstance(called.get("tools"), list)
+    assert isinstance(called.get("response_format"), dict)
 
 
 def test_chop_triggers_embed(tmp_path, monkeypatch):
     dummy_resp = types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
-                message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments="[]")
-                        )
-                    ]
-                )
+                message=types.SimpleNamespace(content="[]")
             )
         ]
     )


### PR DESCRIPTION
## Summary
- update test stubs to return `message.content`
- look for `message.tool_calls` fallback in caption and chop
- assert `response_format` arg for chopping

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590c3b15f08324ae091c9dd8479a17