### PR TITLE
fix(tests): update for structured outputs

### DIFF
--- a/src/caption.py
+++ b/src/caption.py
@@ -114,6 +114,8 @@ def caption_file(path: Path) -> str:
         "additionalProperties": False,
     }
     try:
+        # Structured Outputs returns the content as plain JSON rather than via
+        # the legacy function calling API. This keeps the integration simple.
         resp = openai.chat.completions.create(
             model="gpt-4o-mini",
             messages=message,
@@ -126,8 +128,8 @@ def caption_file(path: Path) -> str:
         raw = resp.choices[0].message.content
         log.info("OpenAI response", text=raw, file=str(path))
         data = json.loads(raw)
-    except Exception:
-        log.exception("Caption failed", sha=sha, file=str(path))
+    except Exception as exc:
+        log.exception("Caption failed", sha=sha, file=str(path), error=str(exc))
         return sha
 
     missing = [l for l in LANGS if f"caption_{l}" not in data]

--- a/src/chop.py
+++ b/src/chop.py
@@ -117,6 +117,8 @@ def process_message(msg_path: Path) -> None:
         },
     }
     try:
+        # Structured Outputs give us a simple JSON string rather than the
+        # function-calling blocks used by older API versions.
         resp = openai.chat.completions.create(
             model="gpt-4o-mini",
             messages=messages,
@@ -129,8 +131,8 @@ def process_message(msg_path: Path) -> None:
         raw = resp.choices[0].message.content
         log.info("OpenAI response", text=raw)
         lots = json.loads(raw)
-    except Exception:
-        log.exception("Failed to chop", file=str(msg_path))
+    except Exception as exc:
+        log.exception("Failed to chop", file=str(msg_path), error=str(exc))
         return
     if isinstance(lots, dict):
         lots = [lots]

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -28,11 +28,7 @@ def test_caption_file_writes(tmp_path, monkeypatch):
         choices=[
             types.SimpleNamespace(
                 message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments='{"caption_en": "desc"}')
-                        )
-                    ]
+                    content='{"caption_en": "desc"}'
                 )
             )
         ]
@@ -61,11 +57,7 @@ def test_caption_logs(tmp_path, monkeypatch):
         choices=[
             types.SimpleNamespace(
                 message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments='{"caption_en": "desc"}')
-                        )
-                    ]
+                    content='{"caption_en": "desc"}'
                 )
             )
         ]

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -23,13 +23,7 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     dummy_resp = types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
-                message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments="[]")
-                        )
-                    ]
-                )
+                message=types.SimpleNamespace(content="[]")
             )
         ]
     )
@@ -49,21 +43,16 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     chop.main([str(msg)])
 
     assert (tmp_path / "lots" / "chat" / "2024" / "05" / "1.json").exists()
-    assert called.get("tool_choice") == "extract_lots"
-    assert isinstance(called.get("tools"), list)
+    fmt = called.get("response_format", {}).get("json_schema", {})
+    assert called.get("response_format", {}).get("type") == "json_schema"
+    assert fmt.get("name") == "extract_lots"
 
 
 def test_chop_triggers_embed(tmp_path, monkeypatch):
     dummy_resp = types.SimpleNamespace(
         choices=[
             types.SimpleNamespace(
-                message=types.SimpleNamespace(
-                    tool_calls=[
-                        types.SimpleNamespace(
-                            function=types.SimpleNamespace(arguments="[]")
-                        )
-                    ]
-                )
+                message=types.SimpleNamespace(content="[]")
             )
         ]
     )


### PR DESCRIPTION
## Summary
- adjust tests to parse structured outputs
- log OpenAI failure details and add comments about new API

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591021db988324a3317770d4b5482a