### PR TITLE
fix(moderation): keep fraud lots without translations

### DIFF
--- a/docs/ontology_housekeeping.md
+++ b/docs/ontology_housekeeping.md
@@ -56,7 +56,8 @@ resolved remove the entries and regenerate the file.
 The chopper generates `title_<lang>` and `description_<lang>` for every lot.
 Every language version must be present. The lot serializer rejects JSON
 files missing any of them and the cleanup step drops such entries so the
-parser can try again.
+parser can try again. Lots marked with `fraud` are exempt from this rule so
+evidence of scams is not lost during maintenance.
 Titles and descriptions should summarise the offer clearly. Popular
 boilerplate text that does not distinguish one ad from another should be
 explicitly discouraged in the prompt so the resulting website lists are

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -15,7 +15,8 @@ All message Markdown files under `data/raw` should have a JSON lot file in
 `data/lots`. Without it the embedder will skip the message. Every lot must
 include translated titles and descriptions for each language. Missing
 translations are treated as an error and the cleanup step removes such files
-so the parser can try again.
+so the parser can try again. Lots flagged with `fraud` are kept even when
+translations are missing so questionable posts can be reviewed later.
 
 ## Vectors
 

--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -77,7 +77,11 @@ def _clean_lots() -> None:
         if not items:
             log.warning("Bad lot file", file=str(path))
             continue
-        if any(not lot.get(f) for lot in items for f in TRANSLATION_FIELDS):
+        missing = any(not lot.get(f) for lot in items for f in TRANSLATION_FIELDS)
+        flagged = any(l.get("fraud") is not None for l in items)
+        # Keep lots flagged as fraud even when translations are missing so
+        # potential scams remain available for manual review.
+        if missing and not flagged:
             path.unlink()
             log.info("Deleted lot", file=str(path), reason="missing translations")
             count += 1

--- a/src/debug_dump.py
+++ b/src/debug_dump.py
@@ -195,6 +195,7 @@ def _message_reason(meta: dict, text: str) -> str | None:
 
 def _lot_reason(lot: dict) -> str | None:
     """Return explanation why ``lot`` would be skipped."""
+    # Fraud reports are kept even when translations are missing so the check comes first.
     if lot.get("fraud") is not None:
         return "fraud"
     if lot.get("contact:telegram") == "@username":

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -108,8 +108,11 @@ def should_skip_message(meta: dict, text: str) -> bool:
 
 def lot_skip_reason(lot: dict) -> str | None:
     """Return the moderation reason for ``lot`` or ``None``."""
+    # Fraud overrides every other rule so the lot can be filtered even when
+    # translations are missing.
     if lot.get("fraud") is not None:
         return "fraud"
+    # Placeholder contacts from examples do not belong on the website.
     if lot.get("contact:telegram") == "@username":
         return "example contact"
     if any(not lot.get(f) for f in REVIEW_FIELDS):

--- a/tests/test_clean_data.py
+++ b/tests/test_clean_data.py
@@ -149,3 +149,20 @@ def test_clean_data_removes_missing_translations(tmp_path, monkeypatch):
     clean_data.main()
 
     assert not bad.exists()
+
+
+def test_clean_data_keeps_fraud_without_translations(tmp_path, monkeypatch):
+    monkeypatch.setattr(clean_data, "RAW_DIR", tmp_path / "raw")
+    monkeypatch.setattr(clean_data, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(clean_data, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(clean_data, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(clean_data, "load_config", lambda: DummyCfg())
+
+    lot_dir = clean_data.LOTS_DIR / "chat" / "2024" / "05"
+    lot_dir.mkdir(parents=True)
+    flagged = lot_dir / "1.json"
+    flagged.write_text(json.dumps([{"_id": "1", "fraud": "spam"}]))
+
+    clean_data.main()
+
+    assert flagged.exists()

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -43,3 +43,8 @@ def test_should_skip_fraud():
         "description_ka": "d",
     }
     assert moderation.should_skip_lot(lot)
+
+
+def test_lot_skip_reason_ignores_missing_when_fraud():
+    lot = {"fraud": "scam", "title_en": "", "description_en": ""}
+    assert moderation.lot_skip_reason(lot) == "fraud"


### PR DESCRIPTION
## Summary
- document that fraud lots are excluded from cleanup if translations are missing
- note the exception in validation docs
- keep fraud lots in clean_data
- clarify why fraud check runs first in moderation
- keep lots with fraud when summarizing moderation
- test that flagged lots survive cleanup
- test that missing translations don't override fraud

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593bca3c5c832499b39835c85eb08c