### PR TITLE
chore(chop): set openai timeout

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -127,6 +127,7 @@ excluded from this list so the parser never wastes API calls on obvious spam.
 The API call now uses Structured Outputs with
 [`chop_schema.json`](chop_schema.json) so titles and descriptions are always
 present. GPT-4o returns the parsed JSON directly without Markdown wrappers.
+The request waits up to fifteen minutes for a reply so slow responses do not halt processing.
 
 ## embed.py
 Generates `text-embedding-3-large` vectors for each lot.  The output is stored

--- a/src/chop.py
+++ b/src/chop.py
@@ -32,6 +32,7 @@ log = get_logger().bind(script=__file__)
 install_excepthook(log)
 
 openai.api_key = OPENAI_KEY
+OPENAI_TIMEOUT = 900  # maximum seconds to wait for GPT-4o
 MEDIA_DIR = Path("data/media")
 LOTS_DIR = Path("data/lots")
 
@@ -130,6 +131,7 @@ def process_message(msg_path: Path) -> None:
             model="gpt-4o-mini",
             messages=messages,
             temperature=0,
+            timeout=OPENAI_TIMEOUT,
             response_format={
                 "type": "json_schema",
                 "json_schema": {

--- a/tests/test_chop.py
+++ b/tests/test_chop.py
@@ -46,6 +46,7 @@ def test_chop_processes_nested(tmp_path, monkeypatch):
     fmt = called.get("response_format", {}).get("json_schema", {})
     assert called.get("response_format", {}).get("type") == "json_schema"
     assert fmt.get("name") == "extract_lots"
+    assert called["timeout"] == chop.OPENAI_TIMEOUT
 
 
 def test_chop_triggers_embed(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `OPENAI_TIMEOUT` constant and set `timeout` on the request
- document the new behavior in `services.md`
- check for `timeout` parameter in chop tests

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593df2d4348324aeb41f34dbae2c93