### PR TITLE
fix(site): preserve raw value in table sort

### DIFF
--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -50,8 +50,8 @@ document.addEventListener('DOMContentLoaded', () => {
       rows.sort((a, b) => {
         const ac = a.cells[idx];
         const bc = b.cells[idx];
-        let A = ac ? (ac.dataset.raw?.trim() || ac.textContent.trim()) : '';
-        let B = bc ? (bc.dataset.raw?.trim() || bc.textContent.trim()) : '';
+        let A = ac?.dataset.raw ?? ac?.textContent.trim() ?? '';
+        let B = bc?.dataset.raw ?? bc?.textContent.trim() ?? '';
         if (type === 'number') {
           A = parseFloat(A);
           B = parseFloat(B);


### PR DESCRIPTION
## Summary
- don't use `.textContent` when sorting so the link markup remains intact

## Testing
- `make precommit`

------
https://chatgpt.com/codex/tasks/task_e_685956ed82448324aff04045e8934676