### PR TITLE
refactor(core): rename vectors to embeddings

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,7 +48,7 @@ make compose
 
 `make update` continues to work as an alias for this pipeline.
 
-This pulls messages (images are captioned immediately and lots are parsed in the background). Chopped lots trigger embedding right away so vectors stay in sync without a separate step. The command finishes by building the static site.
+This pulls messages (images are captioned immediately and lots are parsed in the background). Chopped lots trigger embedding right away so embeddings stay in sync without a separate step. The command finishes by building the static site.
 Run `make caption` or `make chop` separately if you need to reprocess failed images.
 `make caption` now skips files that already have captions so reruns are cheap.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -18,10 +18,10 @@ translations are treated as an error and the cleanup step removes such files
 so the parser can try again. Lots flagged with `fraud` are kept even when
 translations are missing so questionable posts can be reviewed later.
 
-## Vectors
+## Embeddings
 
-Every lot JSON is expected to have an embedding stored in `data/vectors`.
-A vector older than its source lot is treated as stale and reported.
+Every lot JSON is expected to have an embedding stored in `data/embeddings`.
+An embedding file older than its source lot is treated as stale and reported.
 Pages are not generated for lots missing embeddings so incomplete data never
 reaches the website.
 

--- a/scripts/pending_embed.py
+++ b/scripts/pending_embed.py
@@ -19,7 +19,7 @@ from moderation import message_skip_reason, lot_skip_reason
 from post_io import read_post, raw_post_path_from_lot
 
 LOTS_DIR = Path("data/lots")
-VEC_DIR = Path("data/vectors")
+EMBED_DIR = Path("data/embeddings")
 RAW_DIR = Path("data/raw")
 
 log = get_logger().bind(script=__file__)
@@ -82,7 +82,7 @@ def main() -> None:
         lots = read_lots(path) or []
         if not lots:
             continue
-        out = embedding_path(path, VEC_DIR, LOTS_DIR)
+        out = embedding_path(path, EMBED_DIR, LOTS_DIR)
         raw = raw_post_path_from_lot(lots[0], RAW_DIR)
         reason = None
         if raw and raw.exists():

--- a/src/clean_data.py
+++ b/src/clean_data.py
@@ -21,7 +21,7 @@ KEEP_DAYS = getattr(cfg, "KEEP_DAYS", 7)
 
 MEDIA_DIR = Path("data/media")
 LOTS_DIR = Path("data/lots")
-VEC_DIR = Path("data/vectors")
+EMBED_DIR = Path("data/embeddings")
 
 
 def _parse_date(md: Path) -> datetime | None:
@@ -95,19 +95,19 @@ def _clean_lots() -> None:
         log.info("Removed stale lots", count=count)
 
 
-def _clean_vectors() -> None:
-    """Delete vector files when the matching lot JSON is absent."""
+def _clean_embeddings() -> None:
+    """Delete embedding files when the matching lot JSON is absent."""
     count = 0
-    if not VEC_DIR.exists():
+    if not EMBED_DIR.exists():
         return
-    for path in VEC_DIR.rglob("*.json"):
-        lot = LOTS_DIR / path.relative_to(VEC_DIR)
+    for path in EMBED_DIR.rglob("*.json"):
+        lot = LOTS_DIR / path.relative_to(EMBED_DIR)
         if not lot.exists():
             path.unlink()
-            log.info("Deleted vector", file=str(path))
+            log.info("Deleted embedding", file=str(path))
             count += 1
     if count:
-        log.info("Removed orphan vectors", count=count)
+        log.info("Removed orphan embeddings", count=count)
 
 
 def _remove_empty_dirs(root: Path) -> None:
@@ -130,8 +130,8 @@ def main() -> None:
     _clean_raw(cutoff)
     _clean_media(cutoff)
     _clean_lots()
-    _clean_vectors()
-    for root in [RAW_DIR, MEDIA_DIR, LOTS_DIR, VEC_DIR]:
+    _clean_embeddings()
+    for root in [RAW_DIR, MEDIA_DIR, LOTS_DIR, EMBED_DIR]:
         _remove_empty_dirs(root)
 
 

--- a/src/embed.py
+++ b/src/embed.py
@@ -25,18 +25,18 @@ openai.api_key = OPENAI_KEY
 # can be nested several levels deep. ``rglob`` is used to scan everything under
 # the root ``data/lots`` directory.
 LOTS_DIR = Path("data/lots")
-VEC_DIR = Path("data/vectors")
+EMBED_DIR = Path("data/embeddings")
 
 
 
 
 def embed_file(path: Path) -> None:
-    """Embed ``path`` and write the vectors beside it under ``VEC_DIR``."""
+    """Embed ``path`` and write the result beside it under ``EMBED_DIR``."""
     rel = path.relative_to(LOTS_DIR)
-    out = (VEC_DIR / rel).with_suffix(".json")
+    out = (EMBED_DIR / rel).with_suffix(".json")
     out.parent.mkdir(parents=True, exist_ok=True)
     if out.exists() and out.stat().st_mtime >= path.stat().st_mtime:
-        log.debug("Vector up to date", file=str(path))
+        log.debug("Embedding up to date", file=str(path))
         return
 
     lots = read_lots(path)
@@ -66,7 +66,7 @@ def embed_file(path: Path) -> None:
         for i, v in zip(lot_ids, vecs)
     ]
     write_json(out, data)
-    log.debug("Vector written", path=str(out), count=len(data))
+    log.debug("Embedding written", path=str(out), count=len(data))
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/lot_io.py
+++ b/src/lot_io.py
@@ -10,7 +10,7 @@ from log_utils import get_logger
 from serde_utils import load_json, write_json
 
 LOTS_DIR = Path("data/lots")
-VEC_DIR = Path("data/vectors")
+EMBED_DIR = Path("data/embeddings")
 
 log = get_logger().bind(module=__name__)
 
@@ -147,11 +147,11 @@ def lot_json_path(lot_id: str, root: Path) -> Path:
 
 
 def embedding_path(
-    lot_path: Path, vec_root: Path = VEC_DIR, lots_root: Path = LOTS_DIR
+    lot_path: Path, emb_root: Path = EMBED_DIR, lots_root: Path = LOTS_DIR
 ) -> Path:
     """Return embedding file path for ``lot_path``."""
     rel = lot_path.relative_to(lots_root)
-    return (vec_root / rel).with_suffix(".json")
+    return (emb_root / rel).with_suffix(".json")
 
 
 def iter_lot_files(root: Path = LOTS_DIR, newest_first: bool = False) -> list[Path]:

--- a/src/moderation.py
+++ b/src/moderation.py
@@ -53,7 +53,7 @@ BLACKLISTED_USERS = [
 ]
 
 LOTS_DIR = Path("data/lots")
-VEC_DIR = Path("data/vectors")
+EMBED_DIR = Path("data/embeddings")
 
 
 def should_skip_text(text: str) -> bool:
@@ -146,7 +146,7 @@ def apply_to_history() -> None:
         )
         if skip:
             path.unlink()
-            vec = (VEC_DIR / path.relative_to(LOTS_DIR)).with_suffix(".json")
+            vec = (EMBED_DIR / path.relative_to(LOTS_DIR)).with_suffix(".json")
             if vec.exists():
                 vec.unlink()
             removed += 1

--- a/src/similar_utils.py
+++ b/src/similar_utils.py
@@ -1,0 +1,162 @@
+"""Utilities for handling lot embeddings and similar item cache."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from serde_utils import load_json, write_json
+from sklearn.neighbors import NearestNeighbors
+
+from lot_io import LOTS_DIR, EMBED_DIR, lot_json_path
+from log_utils import get_logger
+
+log = get_logger().bind(module=__name__)
+
+SIMILAR_DIR = Path("data/similar")
+
+
+def _load_embeddings() -> dict[str, list[float]]:
+    """Return mapping of lot id to embedding vector."""
+    if not EMBED_DIR.exists():
+        log.info("Embedding directory missing", path=str(EMBED_DIR))
+        return {}
+    data: dict[str, list[float]] = {}
+    for path in EMBED_DIR.rglob("*.json"):
+        obj = load_json(path)
+        if isinstance(obj, dict) and "id" in obj and "vec" in obj:
+            data[obj["id"]] = obj["vec"]
+        elif isinstance(obj, list):
+            for item in obj:
+                if isinstance(item, dict) and "id" in item and "vec" in item:
+                    data[item["id"]] = item["vec"]
+                else:
+                    log.error("Bad embedding entry", file=str(path))
+        else:
+            log.error("Failed to parse embedding file", file=str(path))
+    log.info("Loaded embeddings", count=len(data))
+    return data
+
+
+def _cos_sim(a: list[float], b: list[float]) -> float:
+    """Return cosine similarity between two embeddings."""
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return -1.0
+    return dot / (na * nb)
+
+
+def _format_vector(vec: list[float] | None) -> str | None:
+    """Return compact JSON representation for ``vec``."""
+    if vec is None:
+        return None
+    parts = [f"{v:.4f}".rstrip("0").rstrip(".") for v in vec]
+    return "[" + ",".join(parts) + "]"
+
+
+def _similar_path(lot_path: Path) -> Path:
+    """Return cache file path for ``lot_path`` under ``SIMILAR_DIR``."""
+    rel = lot_path.relative_to(LOTS_DIR)
+    return (SIMILAR_DIR / rel).with_suffix(".json")
+
+
+def _load_similar() -> dict[str, list[dict]]:
+    """Return cached similar lots mapping."""
+    if not SIMILAR_DIR.exists():
+        return {}
+    data: dict[str, list[dict]] = {}
+    for path in SIMILAR_DIR.rglob("*.json"):
+        obj = load_json(path)
+        if isinstance(obj, list):
+            for item in obj:
+                if (
+                    isinstance(item, dict)
+                    and isinstance(item.get("id"), str)
+                    and isinstance(item.get("similar"), list)
+                ):
+                    sims = []
+                    for s in item["similar"]:
+                        if (
+                            isinstance(s, dict)
+                            and isinstance(s.get("id"), str)
+                            and isinstance(s.get("dist"), (int, float))
+                        ):
+                            sims.append({"id": s["id"], "dist": float(s["dist"])} )
+                    if len(sims) == len(item["similar"]):
+                        data[item["id"]] = sims
+    if data:
+        log.info("Loaded similar cache", count=len(data))
+    return data
+
+
+def _save_similar(sim_map: dict[str, list[dict]]) -> None:
+    """Write ``sim_map`` to ``SIMILAR_DIR`` mirroring ``LOTS_DIR`` layout."""
+    files: dict[Path, list] = {}
+    for lot_id, sims in sim_map.items():
+        lot_path = lot_json_path(lot_id, LOTS_DIR)
+        out = _similar_path(lot_path)
+        files.setdefault(out, []).append({"id": lot_id, "similar": sims})
+    for path, items in files.items():
+        write_json(path, items)
+
+
+def _update_reciprocal(sim_map: dict[str, list[dict]], lot_id: str, sims: list[dict]) -> None:
+    """Insert ``lot_id`` into caches of lots listed in ``sims`` if closer."""
+    for entry in sims:
+        other = entry["id"]
+        dist = entry["dist"]
+        items = sim_map.setdefault(other, [])
+        found = False
+        for item in items:
+            if item["id"] == lot_id:
+                item["dist"] = dist
+                found = True
+                break
+        if not found:
+            items.append({"id": lot_id, "dist": dist})
+        items.sort(key=lambda x: x["dist"])
+        if len(items) > 6:
+            del items[6:]
+
+
+def _prune_similar(sim_map: dict[str, list[dict]], valid_ids: set[str]) -> None:
+    """Drop cache entries referring to ids not in ``valid_ids``."""
+    removed = set(sim_map) - valid_ids
+    for key in removed:
+        sim_map.pop(key, None)
+    for items in sim_map.values():
+        items[:] = [i for i in items if i.get("id") in valid_ids]
+
+
+def _calc_similar_nn(
+    sim_map: dict[str, list[dict]],
+    new_ids: list[str],
+    vec_ids: list[str],
+    id_to_vec: dict[str, list[float]],
+) -> None:
+    """Fill ``sim_map`` for ``new_ids`` using a nearest neighbour search."""
+    if not vec_ids:
+        for lid in new_ids:
+            sim_map[lid] = []
+        return
+
+    matrix = [id_to_vec[i] for i in vec_ids]
+    k = min(7, len(matrix))
+    nn = NearestNeighbors(n_neighbors=k, metric="cosine")
+    nn.fit(matrix)
+    index_map = {v: idx for idx, v in enumerate(vec_ids)}
+    for lot_id in new_ids:
+        idx = index_map.get(lot_id)
+        if idx is None:
+            sim_map[lot_id] = []
+            continue
+        dist, neigh = nn.kneighbors([matrix[idx]], n_neighbors=k)
+        sims = []
+        for d, other_idx in zip(dist[0][1:], neigh[0][1:]):
+            other_id = vec_ids[other_idx]
+            sims.append({"id": other_id, "dist": float(d)})
+        sim_map[lot_id] = sims
+        _update_reciprocal(sim_map, lot_id, sims)
+

--- a/templates/category.html
+++ b/templates/category.html
@@ -22,7 +22,7 @@
   </thead>
   <tbody>
   {% for lot in items %}
-    <tr data-id="{{ lot.id }}" data-vector="{{ lot.vec | default('null') | safe }}" data-price="{{ lot.price or '' }}">
+    <tr data-id="{{ lot.id }}" data-embed="{{ lot.embed | default('null') | safe }}" data-price="{{ lot.price or '' }}">
       <td><a href="{{ lot.link }}">{{ lot.title }}</a></td>
       <td>{{ lot.price or '' }}</td>
       <td>{{ lot.seller or '' }}</td>

--- a/templates/lot.html
+++ b/templates/lot.html
@@ -30,7 +30,7 @@
 <script>
   window.currentLot = {
     id: {{ lot['_id']|tojson }},
-    vector: {{ vector|default("null")|safe }}
+    embed: {{ embed|default("null")|safe }}
   };
 </script>
 <h2>{{ _('Similar items') }}</h2>

--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     likeBtn.addEventListener('click', () => {
       let likes = loadList('likes').filter(i => i.id !== window.currentLot.id);
-      likes.push({id: window.currentLot.id, vec: window.currentLot.vector});
+      likes.push({id: window.currentLot.id, vec: window.currentLot.embed});
       saveList('likes', likes);
       let dislikes = loadList('dislikes').filter(i => i.id !== window.currentLot.id);
       saveList('dislikes', dislikes);
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     dislikeBtn.addEventListener('click', () => {
       let dislikes = loadList('dislikes').filter(i => i.id !== window.currentLot.id);
-      dislikes.push({id: window.currentLot.id, vec: window.currentLot.vector});
+      dislikes.push({id: window.currentLot.id, vec: window.currentLot.embed});
       saveList('dislikes', dislikes);
       let likes = loadList('likes').filter(i => i.id !== window.currentLot.id);
       saveList('likes', likes);
@@ -105,7 +105,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const isDataRow = row => row.querySelector('td') !== null;
 
   const price   = row => parseFloat(row.dataset.price);
-  const vector  = row => parseJSON(row.dataset.vector || 'null');
+  const vector  = row => parseJSON(row.dataset.embed || 'null');
   const rawTime = cell =>
       Date.parse(cell.dataset.raw || cell.textContent.trim() || '');
 

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -3,12 +3,15 @@ import json
 import sys
 import os
 import re
+import pytest
 
 os.environ.setdefault("LOG_LEVEL", "INFO")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import build_site
+import similar_utils
+import lot_io
 
 
 class DummyCfg:
@@ -16,11 +19,18 @@ class DummyCfg:
     KEEP_DAYS = 7
 
 
+@pytest.fixture(autouse=True)
+def patch_similar(tmp_path, monkeypatch):
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(similar_utils, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(lot_io, "EMBED_DIR", tmp_path / "vecs")
+
+
 def test_build_site_creates_pages(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -58,7 +68,7 @@ def test_build_site_creates_pages(tmp_path, monkeypatch):
     cat_html = cat_page.read_text()
     assert "hello" in cat_html
     assert "1-0_en.html" in cat_html
-    assert 'data-vector' in cat_html
+    assert 'data-embed' in cat_html
     assert (tmp_path / "views" / "static" / "site.js").exists()
     assert (tmp_path / "views" / "static" / "style.css").exists()
 
@@ -70,7 +80,7 @@ def test_handles_list_fields(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -106,7 +116,7 @@ def test_author_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -144,7 +154,7 @@ def test_build_site_skips_moderated(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -184,7 +194,7 @@ def test_build_site_skips_misparsed(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -218,7 +228,7 @@ def test_build_site_skips_missing_titles(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -246,7 +256,7 @@ def test_images_and_empty_values(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -289,7 +299,7 @@ def test_vectors_generate_similar(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -347,7 +357,7 @@ def test_vectors_nested_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -409,7 +419,7 @@ def test_page_headers_and_orig_open(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "RAW_DIR", tmp_path / "raw")
@@ -472,7 +482,7 @@ def test_drop_lots_without_vectors(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -526,7 +536,7 @@ def test_vector_formatting(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -560,20 +570,20 @@ def test_vector_formatting(tmp_path, monkeypatch):
     build_site.main()
 
     cat_html = (tmp_path / "views" / "deal" / "sell_item_en.html").read_text()
-    m = re.search(r"data-vector=\"([^\"]+)\"", cat_html)
+    m = re.search(r"data-embed=\"([^\"]+)\"", cat_html)
     assert m
     raw = m.group(1)
     assert " " not in raw
     parts = raw.strip("[]").split(",")
     assert all(len(p) <= 7 for p in parts)
-    assert raw == build_site._format_vector(vec)
+    assert raw == similar_utils._format_vector(vec)
 
 
 def test_category_html_parses(tmp_path, monkeypatch):
     monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
     monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
-    monkeypatch.setattr(build_site, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
     monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
@@ -609,3 +619,205 @@ def test_category_html_parses(tmp_path, monkeypatch):
     parser = html5lib.HTMLParser(strict=True)
     parser.parse(cat_html)
     assert parser.errors == []
+
+
+def test_similar_cache_updates(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    (tmp_path / "vecs").mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "a",
+            "description_en": "d",
+            "title_ru": "a",
+            "description_ru": "d",
+            "title_ka": "a",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+    (lots_dir / "2.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "b",
+            "description_en": "d",
+            "title_ru": "b",
+            "description_ru": "d",
+            "title_ka": "b",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+
+    (tmp_path / "vecs" / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (tmp_path / "vecs" / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build_site.main()
+
+    # add new lot and rerun
+    (lots_dir / "3.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "c",
+            "description_en": "d",
+            "title_ru": "c",
+            "description_ru": "d",
+            "title_ka": "c",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+    (tmp_path / "vecs" / "3.json").write_text(json.dumps([{"id": "3-0", "vec": [0.8, 0.2]}]))
+
+    build_site.main()
+
+    sim_file = similar_utils.SIMILAR_DIR / "1.json"
+    data = json.loads(sim_file.read_text())
+    cache = {item["id"]: item["similar"] for item in data}
+    assert any(s["id"] == "3-0" for s in cache["1-0"])
+    assert all("dist" in s for s in cache["1-0"])
+
+
+def test_similar_cache_invalidates_removed(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    (tmp_path / "vecs").mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "a",
+            "description_en": "d",
+            "title_ru": "a",
+            "description_ru": "d",
+            "title_ka": "a",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+    (lots_dir / "2.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "b",
+            "description_en": "d",
+            "title_ru": "b",
+            "description_ru": "d",
+            "title_ka": "b",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+
+    (tmp_path / "vecs" / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (tmp_path / "vecs" / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build_site.main()
+
+    (lots_dir / "2.json").unlink()
+    (tmp_path / "vecs" / "2.json").unlink()
+
+    build_site.main()
+
+    sim_file = similar_utils.SIMILAR_DIR / "1.json"
+    data = json.loads(sim_file.read_text())
+    cache = {item["id"]: item["similar"] for item in data}
+    assert all(s["id"] != "2-0" for s in cache["1-0"])
+
+
+def test_similar_titles_use_language(tmp_path, monkeypatch):
+    class Cfg:
+        LANGS = ["en", "ru"]
+        KEEP_DAYS = 7
+
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(build_site, "load_config", lambda: Cfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    vec_dir = tmp_path / "vecs"
+    vec_dir.mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "hello",
+                "title_ru": "привет",
+                "title_ka": "hello",
+                "description_en": "d",
+                "description_ru": "d",
+                "description_ka": "d",
+                "files": ["a.jpg"],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+    (lots_dir / "2.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "world",
+                "title_ru": "мир",
+                "title_ka": "world",
+                "description_en": "d",
+                "description_ru": "d",
+                "description_ka": "d",
+                "files": ["b.jpg"],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+
+    (vec_dir / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (vec_dir / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build_site.main()
+
+    html_en = (tmp_path / "views" / "1-0_en.html").read_text()
+    html_ru = (tmp_path / "views" / "1-0_ru.html").read_text()
+    assert "world" in html_en
+    assert "мир" in html_ru

--- a/tests/test_clean_data.py
+++ b/tests/test_clean_data.py
@@ -18,7 +18,7 @@ def test_clean_data(tmp_path, monkeypatch):
     monkeypatch.setattr(clean_data, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(clean_data, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(clean_data, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(clean_data, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(clean_data, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(clean_data, "load_config", lambda: DummyCfg())
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=DummyCfg.KEEP_DAYS + 1)
@@ -105,13 +105,13 @@ def test_clean_data(tmp_path, monkeypatch):
         ])
     )
 
-    vec_dir = clean_data.VEC_DIR / "chat" / "2024" / "05"
+    vec_dir = clean_data.EMBED_DIR / "chat" / "2024" / "05"
     vec_dir.mkdir(parents=True)
     v_old = vec_dir / "1.json"
     v_old.write_text("oldvec")
     v_new = vec_dir / "2.json"
     v_new.write_text("newvec")
-    orphan_dir = clean_data.VEC_DIR / "orphan" / "2024" / "05"
+    orphan_dir = clean_data.EMBED_DIR / "orphan" / "2024" / "05"
     orphan_dir.mkdir(parents=True)
     v_orphan = orphan_dir / "3.json"
     v_orphan.write_text("orphan")
@@ -138,7 +138,7 @@ def test_clean_data_removes_missing_translations(tmp_path, monkeypatch):
     monkeypatch.setattr(clean_data, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(clean_data, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(clean_data, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(clean_data, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(clean_data, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(clean_data, "load_config", lambda: DummyCfg())
 
     lot_dir = clean_data.LOTS_DIR / "chat" / "2024" / "05"
@@ -155,7 +155,7 @@ def test_clean_data_keeps_fraud_without_translations(tmp_path, monkeypatch):
     monkeypatch.setattr(clean_data, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(clean_data, "MEDIA_DIR", tmp_path / "media")
     monkeypatch.setattr(clean_data, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(clean_data, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(clean_data, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(clean_data, "load_config", lambda: DummyCfg())
 
     lot_dir = clean_data.LOTS_DIR / "chat" / "2024" / "05"

--- a/tests/test_debug_dump.py
+++ b/tests/test_debug_dump.py
@@ -50,7 +50,7 @@ def test_delete_files(tmp_path, monkeypatch):
     media_dir.mkdir()
 
     monkeypatch.setattr(debug_dump, "LOTS_DIR", lots_dir)
-    monkeypatch.setattr(debug_dump, "VEC_DIR", vec_dir)
+    monkeypatch.setattr(debug_dump, "EMBED_DIR", vec_dir)
     monkeypatch.setattr(debug_dump, "RAW_DIR", raw_dir)
     monkeypatch.setattr(debug_dump, "MEDIA_DIR", media_dir)
 
@@ -88,7 +88,7 @@ def test_skip_fetch_when_cached(tmp_path, monkeypatch):
     lot_id = "chat/2024/01/1"
 
     monkeypatch.setattr(debug_dump, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(debug_dump, "VEC_DIR", tmp_path / "vec")
+    monkeypatch.setattr(debug_dump, "EMBED_DIR", tmp_path / "vec")
     monkeypatch.setattr(debug_dump, "RAW_DIR", tmp_path / "raw")
     monkeypatch.setattr(debug_dump, "MEDIA_DIR", tmp_path / "media")
 
@@ -111,7 +111,7 @@ def test_skip_fetch_when_cached(tmp_path, monkeypatch):
 def test_moderation_summary(tmp_path, monkeypatch):
     monkeypatch.setattr(debug_dump, "LOTS_DIR", tmp_path / "lots")
     monkeypatch.setattr(debug_dump, "RAW_DIR", tmp_path / "raw")
-    monkeypatch.setattr(debug_dump, "VEC_DIR", tmp_path / "vec")
+    monkeypatch.setattr(debug_dump, "EMBED_DIR", tmp_path / "vec")
     monkeypatch.setattr(debug_dump, "MEDIA_DIR", tmp_path / "media")
 
     lot_id = "chat/2024/01/1"
@@ -125,11 +125,11 @@ def test_moderation_summary(tmp_path, monkeypatch):
 
     summary = debug_dump.moderation_summary(lot_id)
     assert "banned phrase" in summary
-    assert "vectors: missing" in summary
+    assert "embeddings: missing" in summary
 
-    vec_path = debug_dump.VEC_DIR / f"{lot_id}.json"
+    vec_path = debug_dump.EMBED_DIR / f"{lot_id}.json"
     vec_path.parent.mkdir(parents=True, exist_ok=True)
     vec_path.write_text('[{"id": "x", "vec": [1]}]')
     summary = debug_dump.moderation_summary(lot_id)
-    assert "vectors: ok" in summary
+    assert "embeddings: ok" in summary
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -29,7 +29,7 @@ import embed
 
 def test_embed_file(tmp_path, monkeypatch):
     monkeypatch.setattr(embed, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(embed, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(embed, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(embed, "openai", dummy_openai)
 
     path = tmp_path / "lots" / "chat" / "2024" / "05" / "1.json"

--- a/tests/test_pending_embed.py
+++ b/tests/test_pending_embed.py
@@ -13,7 +13,7 @@ from serde_utils import load_json
 
 def test_upgrade_legacy_format(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(pending_embed, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(pending_embed, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(pending_embed, "EMBED_DIR", tmp_path / "vecs")
 
     path = pending_embed.LOTS_DIR / "1.json"
     path.parent.mkdir(parents=True)
@@ -29,7 +29,7 @@ def test_upgrade_legacy_format(tmp_path, monkeypatch, capsys):
     }
     path.write_text(json.dumps([lot]))
 
-    vec = pending_embed.VEC_DIR / "1.json"
+    vec = pending_embed.EMBED_DIR / "1.json"
     vec.parent.mkdir(parents=True)
     vec.write_text(json.dumps({"id": "x", "vec": [1]}))
 
@@ -43,7 +43,7 @@ def test_upgrade_legacy_format(tmp_path, monkeypatch, capsys):
 
 def test_vector_count_mismatch(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(pending_embed, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(pending_embed, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(pending_embed, "EMBED_DIR", tmp_path / "vecs")
 
     path = pending_embed.LOTS_DIR / "1.json"
     path.parent.mkdir(parents=True)
@@ -69,7 +69,7 @@ def test_vector_count_mismatch(tmp_path, monkeypatch, capsys):
     }
     path.write_text(json.dumps([lot1, lot2]))
 
-    vec = pending_embed.VEC_DIR / "1.json"
+    vec = pending_embed.EMBED_DIR / "1.json"
     vec.parent.mkdir(parents=True)
     vec.write_text(json.dumps([{"id": "x", "vec": [1]}]))
 
@@ -103,7 +103,7 @@ def test_cli_runs(tmp_path):
 
 def test_skip_due_to_moderation(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(pending_embed, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(pending_embed, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(pending_embed, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(pending_embed, "RAW_DIR", tmp_path / "raw")
 
     lot_dir = pending_embed.LOTS_DIR
@@ -134,7 +134,7 @@ def test_skip_due_to_moderation(tmp_path, monkeypatch, capsys):
 
 def test_does_not_skip_on_raw_parse_error(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(pending_embed, "LOTS_DIR", tmp_path / "lots")
-    monkeypatch.setattr(pending_embed, "VEC_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(pending_embed, "EMBED_DIR", tmp_path / "vecs")
     monkeypatch.setattr(pending_embed, "RAW_DIR", tmp_path / "raw")
 
     lot_dir = pending_embed.LOTS_DIR


### PR DESCRIPTION
## Summary
- rename vector constants to embedding constants
- update docs to reflect `data/embeddings`
- store per-lot embedding string under `data-embed`
- adjust JS and tests for new attribute names

## Testing
- `make precommit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a5ccfd8d083248b705e30ba74ce7a