### PR TITLE
chore(test): add coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source = src
+
+[report]
+omit =
+    tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-cov
       - name: Lint and compile
         run: make precommit
       - name: Run tests
-        run: pytest -v
+        run: pytest -v --cov=src --cov-report=xml
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ session*
 config.py
 errors.log
 *.mo
+.coverage
+htmlcov/
+coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,6 @@ clean: ## Delete all temporary files
 precommit: ## Run pre-commit checks
 	@find src -name '*.py' -print0 | xargs -0 scripts/check_python.sh
 	python scripts/check_translations.py
+
+test: ## Run unit tests with coverage
+	pytest --cov=src --cov-report=term-missing

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -20,6 +20,7 @@ If you prefer isolated dependencies create a virtual environment and use the
 python3 -m venv .venv
 . .venv/bin/activate
 pip install -r requirements.txt
+pip install pytest pytest-cov
 ```
 
 Copy the example configuration and edit it with your credentials:
@@ -56,7 +57,7 @@ Run the test suite and linter before committing:
 
 ```bash
 make precommit
-pytest
+pytest --cov=src --cov-report=term-missing
 ```
 
 For offline smoke tests you can enable testing mode:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ telethon
 scikit-learn
 progressbar2
 html5lib
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- add pytest and coverage dependencies
- ignore coverage outputs
- add `test` target running tests with coverage
- document running tests with coverage
- generate coverage in CI and upload to Codecov

## Testing
- `make precommit`
- `pytest --cov=src --cov-report=term-missing --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_685a782816748324b136c8b6d8bddebd