### PR TITLE
docs(setup): add pytest to deb deps

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,7 @@
 # Setup and Usage
 
-This project uses Python 3.12.  On Debian based distributions the required
-modules are available as packages:
+This project uses Python 3.12.
+On Debian based distributions the required modules are available as packages:
 
 ```bash
 sudo apt install python3-openai \
@@ -10,6 +10,7 @@ sudo apt install python3-openai \
     python3-structlog python3-telethon \
     python3-sklearn python3-progressbar2 \
     python3-html5lib \
+    python3-pytest python3-pytest-cov \
     gettext  # provides msgfmt used to compile translations
 ```
 


### PR DESCRIPTION
## Summary
- list `python3-pytest` and `python3-pytest-cov` in the Debian install instructions
- split the setup text so each sentence is on its own line

## Testing
- `make precommit`
- `pytest --cov=src --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_685a7a85a4d083249bd8fc460e59aca9