### PR TITLE
fix(chop): refine multi-lot handling

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -115,8 +115,9 @@ items for men, women or kids. Ads posted to the wrong chat
 `fraud=spam` even when they look legitimate.
 
 ## chop.py
-Feeds the message text plus any media captions to GPT‑4o‑mini to extract
-individual lots with a fallback to GPT‑4o when the result is incomplete.
+Feeds the message text plus any media captions to GPT‑4o‑mini first. If the
+model returns more than one lot or an incomplete result the same post is
+reprocessed with GPT‑4o so pictures are matched to the correct lot.
 `chop.py` marks the start of the original message with `Message text:` so
 the LLM does not confuse it with captions. Each caption is preceded by its
 filename. The script processes a single Markdown file path provided on the

--- a/prompts/chopper_prompt.md
+++ b/prompts/chopper_prompt.md
@@ -51,6 +51,7 @@ The output is a flat dictionary inspired by OpenStreetMap tags. Important keys i
 - `laundry` - `yes` when a separate laundry room is available.
 - `contact:phone`, `contact:telegram`, `contact:instagram`, `contact:viber`, `contact:whatsapp`, `contact:website` – stripped to digits in full international format or `@username`. If a phone number is specifically advertised for Telegram, store it in both `contact:phone` and `contact:telegram`.
 - `files` – list of stored media paths for the lot. Match the files to their respective lots. Put most representative picture first - it will be used on post preview.
+When a post contains more than one lot assign each captioned image to exactly one lot based on context. Reuse a picture only when it clearly shows every item offered together.
 
 Additional nuggets like parking, balcony or urgency can be added as they appear. Only include keys you are confident about; omit unknown fields to keep the JSON lean.
 


### PR DESCRIPTION
## Summary
- clarify in the chopper prompt how files map to lots
- explain fallback logic in services docs
- reprocess multi-lot results with gpt-4o
- test rerun when gpt-4o-mini outputs multiple lots

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1f88574083248fabfdc4b802f1a3