### PR TITLE
feat(similar): accelerate search with batch knn

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -170,6 +170,8 @@ distances in `data/similar`.  The directory mirrors `data/lots` so stale entries
 can be identified easily.  Before calculating new recommendations the cache is
 pruned from references to missing lots. When a new lot is added the reciprocal
 caches of the posts it links to are updated if the new entry ranks higher.
+The progress bar shows how many lots were processed during recommendation
+generation and the search now runs in one batch which shortens the wait time.
 Code handling embedding loading and recommendation caching resides in
 `src/similar_utils.py` to keep `build_site.py` concise.  Titles and thumbnails
 are resolved from the lot JSON when pages are rendered so each language shows


### PR DESCRIPTION
## Summary
- speed up `_calc_similar_nn` with a single KNN run
- display a progress bar for similarity computation
- document the new behaviour

## Testing
- `make precommit`


------
https://chatgpt.com/codex/tasks/task_e_685c2691aff8832491544f41320c4d78