### PR TITLE
build: add similar cache target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,12 @@ ontology: chop ## Summarize lots so it's easier see what exactly is there in the
 embed: chop caption ## Store embeddings for each lot
 	python scripts/pending_embed.py | parallel --eta -j16 -0 python src/embed.py
 
+# Update cache of similar items based on embeddings.
+similar: embed ## Compute lot recommendations
+	python src/similar.py
+
 # Render HTML pages from lots and templates.
-build: embed ontology ## Render HTML pages from lots and templates
+build: similar ontology ## Render HTML pages from lots and templates
 	rm -rf data/views/*
 	python src/build_site.py
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -160,21 +160,21 @@ Translations are now produced by `chop.py` itself.  Fields like
 use the street name together with room count, floor level and view where
 applicable so that every language has a meaningful summary.
 
+## similar.py
+Calculates nearest neighbour recommendations for each lot. Embeddings come from
+`data/embeddings` and lots from `data/lots`. Stale entries are pruned before
+running a cosine search via scikit‑learn. The top six neighbours for every lot
+are stored under `data/similar` mirroring the lot layout. Run `make similar` to
+refresh this cache.
+
 ## build_site.py
 Renders the static marketplace website using Jinja templates.  Lots are read
 from `data/lots` and written to `data/views`.  The script loads
 `ontology/fields.json` to order attribute tables and embeddings from `data/embeddings` to suggest
-similar lots.  Vector files without a matching lot are dropped before computing
-similarity so stale data never bloats memory. Similarity search now relies on
-`scikit-learn` and stores the top six neighbour ids with their cosine
-distances in `data/similar`.  The directory mirrors `data/lots` so stale entries
-can be identified easily.  Before calculating new recommendations the cache is
-pruned from references to missing lots. When a new lot is added the reciprocal
-caches of the posts it links to are updated if the new entry ranks higher.
-The progress bar shows how many lots were processed during recommendation
-generation and the search now runs in one batch which shortens the wait time.
-Code handling embedding loading and recommendation caching resides in
-`src/similar_utils.py` to keep `build_site.py` concise.  Titles and thumbnails
+similar lots. Recommendations are read from the cache in `data/similar` and the
+site still renders even when the cache is missing or outdated. Code handling
+embedding loading and recommendation caching resides in `src/similar_utils.py`
+to keep `build_site.py` concise. Titles and thumbnails
 are resolved from the lot JSON when pages are rendered so each language shows
 the correct translation. Lots without embeddings are skipped entirely during
 rendering. A regression model (see ``src/price_utils.py``) derives ``ai_price``

--- a/src/build_site.py
+++ b/src/build_site.py
@@ -28,9 +28,6 @@ from similar_utils import (
     _load_embeddings,
     _format_vector,
     _load_similar,
-    _save_similar,
-    _prune_similar,
-    _calc_similar_nn,
     _cos_sim,
     _sync_embeddings,
     _similar_by_user,
@@ -656,13 +653,6 @@ def main() -> None:
         use_rates = ai_rates
     prepare_price_fields(lots, use_rates, display_cur)
 
-    log.info("Computing similar lots", count=len(lots))
-    lot_keys = {lot["_id"] for lot in lots}
-    _prune_similar(sim_map, lot_keys)
-    new_ids = [i for i in lot_keys if i not in sim_map]
-    vec_ids = [i for i in lot_keys if id_to_vec.get(i)]
-    _calc_similar_nn(sim_map, new_ids, vec_ids, id_to_vec)
-
     more_user_map = _similar_by_user(lots, id_to_vec)
     categories, category_stats, _recent = _categorise(
         lots, langs, keep_days, id_to_vec
@@ -684,7 +674,6 @@ def main() -> None:
         display_cur,
     )
 
-    _save_similar(sim_map)
     log.info("Site build complete")
 
 

--- a/src/similar.py
+++ b/src/similar.py
@@ -1,0 +1,73 @@
+"""Calculate similarity recommendations for all lots."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from log_utils import get_logger, install_excepthook
+from lot_io import iter_lot_files, read_lots
+from post_io import RAW_DIR, read_post, raw_post_path
+from moderation import should_skip_message, should_skip_lot
+from similar_utils import (
+    _load_embeddings,
+    _load_similar,
+    _save_similar,
+    _prune_similar,
+    _calc_similar_nn,
+    _sync_embeddings,
+)
+
+log = get_logger().bind(script=__file__)
+install_excepthook(log)
+
+LOTS_DIR = Path("data/lots")
+
+
+def _iter_lots() -> list[dict]:
+    """Return lots filtered by moderation rules."""
+    lots: list[dict] = []
+    for path in iter_lot_files(LOTS_DIR):
+        data = read_lots(path)
+        if not data:
+            continue
+        rel = path.relative_to(LOTS_DIR).with_suffix("")
+        base = rel.name
+        prefix = rel.parent
+        for i, lot in enumerate(data):
+            src = lot.get("source:path")
+            meta: dict[str, str] | None = None
+            text = ""
+            if src:
+                raw_path = raw_post_path(src, RAW_DIR)
+                meta, text = read_post(raw_path)
+                if should_skip_message(meta, text):
+                    continue
+            if should_skip_lot(lot):
+                continue
+            lot["_id"] = str(prefix / f"{base}-{i}") if prefix.parts else f"{base}-{i}"
+            lots.append(lot)
+    log.info("Loaded lots", count=len(lots))
+    return lots
+
+
+def main() -> None:
+    """Update ``data/similar`` using available embeddings."""
+    log.info("Computing similar lots")
+    embeddings = _load_embeddings()
+    lots = _iter_lots()
+    sim_map = _load_similar()
+
+    lots, embeddings = _sync_embeddings(lots, embeddings)
+    id_to_vec = {lot["_id"]: embeddings.get(lot["_id"]) for lot in lots}
+    lot_keys = {lot["_id"] for lot in lots}
+    _prune_similar(sim_map, lot_keys)
+    new_ids = [i for i in lot_keys if i not in sim_map]
+    vec_ids = [i for i in lot_keys if id_to_vec.get(i)]
+    _calc_similar_nn(sim_map, new_ids, vec_ids, id_to_vec)
+
+    _save_similar(sim_map)
+    log.info("Similar cache updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_similar.py
+++ b/tests/test_similar.py
@@ -1,0 +1,406 @@
+import json
+import sys
+from pathlib import Path
+import os
+import re
+import pytest
+
+os.environ.setdefault("LOG_LEVEL", "INFO")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import build_site
+import similar
+import similar_utils
+import lot_io
+
+
+class DummyCfg:
+    LANGS = ["en"]
+    KEEP_DAYS = 7
+    DISPLAY_CURRENCY = "USD"
+
+
+@pytest.fixture(autouse=True)
+def patch_similar(tmp_path, monkeypatch):
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(similar_utils, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(lot_io, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setenv("ALLOW_EMPTY_POSTERS", "1")
+
+
+@pytest.fixture
+def build(monkeypatch):
+    def run():
+        similar.main()
+        build_site.main()
+
+    return run
+
+
+def test_vectors_generate_similar(tmp_path, monkeypatch, build):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    vec_dir = tmp_path / "vecs"
+    vec_dir.mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "a",
+                "description_en": "d",
+                "title_ru": "a",
+                "description_ru": "d",
+                "title_ka": "a",
+                "description_ka": "d",
+                "files": [],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+    (lots_dir / "2.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "b",
+                "description_en": "d",
+                "title_ru": "b",
+                "description_ru": "d",
+                "title_ka": "b",
+                "description_ka": "d",
+                "files": [],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+
+    (vec_dir / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (vec_dir / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build()
+
+    html = (tmp_path / "views" / "1-0_en.html").read_text()
+    assert "2-0_en.html" in html
+
+
+def test_vectors_nested_paths(tmp_path, monkeypatch, build):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots" / "chat" / "2024"
+    lots_dir.mkdir(parents=True)
+    (tmp_path / "media").mkdir()
+    vec_dir = tmp_path / "vecs" / "chat" / "2024"
+    vec_dir.mkdir(parents=True)
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "a",
+                "description_en": "d",
+                "title_ru": "a",
+                "description_ru": "d",
+                "title_ka": "a",
+                "description_ka": "d",
+                "files": [],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+    (lots_dir / "2.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "b",
+                "description_en": "d",
+                "title_ru": "b",
+                "description_ru": "d",
+                "title_ka": "b",
+                "description_ka": "d",
+                "files": [],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+
+    (vec_dir / "1.json").write_text(
+        json.dumps([{"id": "chat/2024/1-0", "vec": [1, 0]}])
+    )
+    (vec_dir / "2.json").write_text(
+        json.dumps([{"id": "chat/2024/2-0", "vec": [0.9, 0.1]}])
+    )
+
+    build()
+
+    html = (tmp_path / "views" / "chat" / "2024" / "1-0_en.html").read_text()
+    assert "2-0_en.html" in html
+
+
+def test_vector_formatting(tmp_path, monkeypatch, build):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    vec_dir = tmp_path / "vecs"
+    vec_dir.mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "a",
+            "description_en": "d",
+            "title_ru": "a",
+            "description_ru": "d",
+            "title_ka": "a",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        },
+    ]))
+
+    vec = [0.123456, -0.987654]
+    (vec_dir / "1.json").write_text(json.dumps([{"id": "1-0", "vec": vec}]))
+
+    build()
+
+    cat_html = (tmp_path / "views" / "deal" / "sell_item_en.html").read_text()
+    m = re.search(r"data-embed=\"([^\"]+)\"", cat_html)
+    assert m
+    raw = m.group(1)
+    assert " " not in raw
+    parts = raw.strip("[]").split(",")
+    assert all(len(p) <= 7 for p in parts)
+    assert raw == similar_utils._format_vector(vec)
+
+
+def test_similar_cache_updates(tmp_path, monkeypatch, build):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    (tmp_path / "vecs").mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "a",
+            "description_en": "d",
+            "title_ru": "a",
+            "description_ru": "d",
+            "title_ka": "a",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+    (lots_dir / "2.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "b",
+            "description_en": "d",
+            "title_ru": "b",
+            "description_ru": "d",
+            "title_ka": "b",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+
+    (tmp_path / "vecs" / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (tmp_path / "vecs" / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build()
+
+    (lots_dir / "3.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "c",
+            "description_en": "d",
+            "title_ru": "c",
+            "description_ru": "d",
+            "title_ka": "c",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+    (tmp_path / "vecs" / "3.json").write_text(json.dumps([{"id": "3-0", "vec": [0.8, 0.2]}]))
+
+    build()
+
+    sim_file = similar_utils.SIMILAR_DIR / "1.json"
+    data = json.loads(sim_file.read_text())
+    cache = {item["id"]: item["similar"] for item in data}
+    assert any(s["id"] == "3-0" for s in cache["1-0"])
+    assert all("dist" in s for s in cache["1-0"])
+
+
+def test_similar_cache_invalidates_removed(tmp_path, monkeypatch, build):
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(build_site, "load_config", lambda: DummyCfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    (tmp_path / "media").mkdir()
+    (tmp_path / "vecs").mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "a",
+            "description_en": "d",
+            "title_ru": "a",
+            "description_ru": "d",
+            "title_ka": "a",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+    (lots_dir / "2.json").write_text(json.dumps([
+        {
+            "timestamp": now,
+            "title_en": "b",
+            "description_en": "d",
+            "title_ru": "b",
+            "description_ru": "d",
+            "title_ka": "b",
+            "description_ka": "d",
+            "files": [],
+            "market:deal": "sell_item",
+        }
+    ]))
+
+    (tmp_path / "vecs" / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (tmp_path / "vecs" / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build()
+
+    (lots_dir / "2.json").unlink()
+    (tmp_path / "vecs" / "2.json").unlink()
+
+    build()
+
+    sim_file = similar_utils.SIMILAR_DIR / "1.json"
+    data = json.loads(sim_file.read_text())
+    cache = {item["id"]: item["similar"] for item in data}
+    assert all(s["id"] != "2-0" for s in cache["1-0"])
+
+
+def test_similar_titles_use_language(tmp_path, monkeypatch, build):
+    class Cfg:
+        LANGS = ["en", "ru"]
+        KEEP_DAYS = 7
+
+    monkeypatch.setattr(build_site, "LOTS_DIR", tmp_path / "lots")
+    monkeypatch.setattr(build_site, "VIEWS_DIR", tmp_path / "views")
+    monkeypatch.setattr(build_site, "TEMPLATES", Path("templates"))
+    monkeypatch.setattr(build_site, "EMBED_DIR", tmp_path / "vecs")
+    monkeypatch.setattr(build_site, "ONTOLOGY", tmp_path / "ont.json")
+    monkeypatch.setattr(build_site, "MEDIA_DIR", tmp_path / "media")
+    monkeypatch.setattr(similar_utils, "SIMILAR_DIR", tmp_path / "similar")
+    monkeypatch.setattr(build_site, "load_config", lambda: Cfg())
+
+    lots_dir = tmp_path / "lots"
+    lots_dir.mkdir()
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    vec_dir = tmp_path / "vecs"
+    vec_dir.mkdir()
+
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    (lots_dir / "1.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "hello",
+                "title_ru": "привет",
+                "title_ka": "hello",
+                "description_en": "d",
+                "description_ru": "d",
+                "description_ka": "d",
+                "files": ["a.jpg"],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+    (lots_dir / "2.json").write_text(
+        json.dumps([
+            {
+                "timestamp": now,
+                "title_en": "world",
+                "title_ru": "мир",
+                "title_ka": "world",
+                "description_en": "d",
+                "description_ru": "d",
+                "description_ka": "d",
+                "files": ["b.jpg"],
+                "market:deal": "sell_item",
+            }
+        ])
+    )
+
+    (vec_dir / "1.json").write_text(json.dumps([{"id": "1-0", "vec": [1, 0]}]))
+    (vec_dir / "2.json").write_text(json.dumps([{"id": "2-0", "vec": [0.9, 0.1]}]))
+
+    build()
+
+    html_en = (tmp_path / "views" / "1-0_en.html").read_text()
+    html_ru = (tmp_path / "views" / "1-0_ru.html").read_text()
+    assert "world" in html_en
+    assert "мир" in html_ru


### PR DESCRIPTION
## Summary
- move recommendation code to new `similar.py`
- load cached recommendations in `build_site.py`
- call new script from `Makefile`
- update docs with new target
- adapt tests to call a helper that also runs `similar.py`
- split similar tests into a new module

## Testing
- `make precommit` *(fails: ModuleNotFoundError: No module named 'graphviz')*
- `make test` *(fails: Unable to locate package python3-openai)*

------
https://chatgpt.com/codex/tasks/task_e_685d0e5522d08324b11d52a2338afd83