### PR TITLE
feat(build): cluster sell items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,20 @@ embed: chop caption ## Store embeddings for each lot
 
 # Update cache of similar items based on embeddings.
 similar: embed ## Compute lot recommendations
-	python src/similar.py
+	        python src/similar.py
 
 # Train price regression model and save it under ``data/price_model.json``.
 prices: embed ## Train price model
-	python src/price_train.py
+	        python src/price_train.py
+
+# Cluster item categories from embeddings.
+clusters: embed ## Group item types into clusters
+	python src/cluster_items.py
 
 # Render HTML pages from lots and templates.
-build: prices similar ontology ## Render HTML pages from lots and templates
-	rm -rf data/views/*
-	python src/build_site.py
+build: prices similar clusters ontology ## Render HTML pages from lots and templates
+	        rm -rf data/views/*
+	        python src/build_site.py
 
 deploy: build ## Deploy built static website to the server
 	rsync --delete-before --size-only -zz --compress-choice=zstd --compress-level=3 --omit-dir-times --omit-link-times --info=stats2,progress2 -aH -e "ssh -T -c aes128-ctr -o Compression=no" data/views/ 178.62.209.164:/srv/www/batumarket/

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ embed: chop caption ## Store embeddings for each lot
 
 # Update cache of similar items based on embeddings.
 similar: embed ## Compute lot recommendations
-	        python src/similar.py
+	python src/similar.py
 
 # Train price regression model and save it under ``data/price_model.json``.
 prices: embed ## Train price model
-	        python src/price_train.py
+	python src/price_train.py
 
 # Cluster item categories from embeddings.
 clusters: embed ## Group item types into clusters
@@ -53,8 +53,8 @@ clusters: embed ## Group item types into clusters
 
 # Render HTML pages from lots and templates.
 build: prices similar clusters ontology ## Render HTML pages from lots and templates
-	        rm -rf data/views/*
-	        python src/build_site.py
+	rm -rf data/views/*
+	python src/build_site.py
 
 deploy: build ## Deploy built static website to the server
 	rsync --delete-before --size-only -zz --compress-choice=zstd --compress-level=3 --omit-dir-times --omit-link-times --info=stats2,progress2 -aH -e "ssh -T -c aes128-ctr -o Compression=no" data/views/ 178.62.209.164:/srv/www/batumarket/

--- a/docs/services.md
+++ b/docs/services.md
@@ -198,6 +198,9 @@ back to the predicted amount when no explicit price is available. Displayed
 prices are converted to ``DISPLAY_CURRENCY`` and aligned with a grey tint when
 coming from the model.
 Embedding arrays are written as compact JSON with each number using no more than seven characters and no spaces.
+
+## cluster_items.py
+Groups all ``sell_item`` lots using their embeddings so similar offers end up on the same page. The script aims for roughly thirty posts per cluster. Each cluster name joins the original ``item:type`` labels ordered by how close their centroids are to the cluster centre. Results go to ``data/item_clusters.json`` and ``build_site.py`` uses them instead of plain ``item:type`` pages. Run ``make clusters`` after embedding lots.
 Each lot page shows images in a small carousel,
 scaled to at most 40% of the viewport height, a table of
 all recognised fields and a link back to the Telegram post.  Pages are

--- a/src/cluster_items.py
+++ b/src/cluster_items.py
@@ -12,7 +12,6 @@ from notes_utils import write_json
 from sklearn.cluster import KMeans
 
 log = get_logger().bind(script=__file__)
-install_excepthook(log)
 
 LOTS_DIR = Path("data/lots")
 OUTPUT_FILE = Path("data/item_clusters.json")
@@ -98,6 +97,7 @@ def collect_clusters() -> dict[str, list[str]]:
 
 def main() -> None:
     """Cluster items and save the result."""
+    install_excepthook(log)
     log.info("Clustering items")
     clusters = collect_clusters()
     OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cluster_items.py
+++ b/src/cluster_items.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+from collections import defaultdict
+from typing import Iterable
+
+from log_utils import get_logger, install_excepthook
+from lot_io import iter_lot_files, read_lots
+from similar_utils import _load_embeddings, _sync_embeddings, _cos_sim
+from notes_utils import write_json
+
+from sklearn.cluster import KMeans
+
+log = get_logger().bind(script=__file__)
+install_excepthook(log)
+
+LOTS_DIR = Path("data/lots")
+OUTPUT_FILE = Path("data/item_clusters.json")
+
+
+def _iter_lots() -> list[dict]:
+    """Return all lots with generated ids."""
+    lots: list[dict] = []
+    for path in iter_lot_files(LOTS_DIR):
+        data = read_lots(path)
+        if not data:
+            continue
+        rel = path.relative_to(LOTS_DIR).with_suffix("")
+        base = rel.name
+        prefix = rel.parent
+        for i, lot in enumerate(data):
+            lot["_id"] = str(prefix / f"{base}-{i}") if prefix.parts else f"{base}-{i}"
+            lots.append(lot)
+    log.info("Loaded lots", count=len(lots))
+    return lots
+
+
+def collect_clusters() -> dict[str, list[str]]:
+    """Return mapping of cluster name to lot ids."""
+    log.debug("Loading embeddings")
+    embeds = _load_embeddings()
+    log.debug("Loading lots")
+    lots = _iter_lots()
+    lots, embeds = _sync_embeddings(lots, embeds)
+    id_to_vec = {lot["_id"]: embeds.get(lot["_id"]) for lot in lots}
+
+    items: list[tuple[str, str, list[float]]] = []
+    for lot in lots:
+        if lot.get("market:deal") != "sell_item":
+            continue
+        itype = lot.get("item:type")
+        if isinstance(itype, list):
+            itype = itype[0] if itype else None
+        if not isinstance(itype, str) or not itype:
+            continue
+        vec = id_to_vec.get(lot["_id"])
+        if vec is None:
+            continue
+        items.append((lot["_id"], itype, vec))
+
+    if not items:
+        return {}
+
+    vectors = [it[2] for it in items]
+    n_clusters = max(1, round(len(items) / 30))
+    n_clusters = min(n_clusters, len(items))
+    km = KMeans(n_clusters=n_clusters, n_init="auto", random_state=0)
+    labels = km.fit_predict(vectors)
+
+    grouped: dict[int, list[tuple[str, str, list[float]]]] = defaultdict(list)
+    for lab, item in zip(labels, items):
+        grouped[int(lab)].append(item)
+
+    result: dict[str, list[str]] = {}
+    for items in grouped.values():
+        dims = len(items[0][2])
+        centroid = [0.0] * dims
+        for _, _, vec in items:
+            for i, v in enumerate(vec):
+                centroid[i] += v
+        centroid = [v / len(items) for v in centroid]
+
+        type_vecs: dict[str, list[list[float]]] = defaultdict(list)
+        for lid, itype, vec in items:
+            type_vecs[itype].append(vec)
+
+        scores = []
+        for itype, vecs in type_vecs.items():
+            mean = [sum(v[i] for v in vecs) / len(vecs) for i in range(dims)]
+            sim = _cos_sim(mean, centroid)
+            scores.append((sim, itype))
+        scores.sort(reverse=True)
+        name = " ".join(t for _, t in scores)
+        result[name] = [lid for lid, _, _ in items]
+
+    return result
+
+
+def main() -> None:
+    """Cluster items and save the result."""
+    log.info("Clustering items")
+    clusters = collect_clusters()
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    write_json(OUTPUT_FILE, clusters)
+    log.info("Wrote clusters", path=str(OUTPUT_FILE), count=len(clusters))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -575,13 +575,17 @@ def test_sell_item_subcategories(tmp_path, monkeypatch, build):
         ])
     )
 
+    clusters = {"smartphone laptop": ["1-0", "1-1"]}
+    monkeypatch.setattr(build_site, "CLUSTER_FILE", tmp_path / "clusters.json")
+    (tmp_path / "clusters.json").write_text(json.dumps(clusters))
+
     build()
 
-    assert (tmp_path / "views" / "deal" / "sell_item.smartphone_en.html").exists()
-    assert (tmp_path / "views" / "deal" / "sell_item.laptop_en.html").exists()
+    assert (
+        tmp_path / "views" / "deal" / "sell_item.smartphone laptop_en.html"
+    ).exists()
     root_html = (tmp_path / "views" / "deal" / "sell_item_en.html").read_text()
-    assert "smartphone" in root_html
-    assert "laptop" in root_html
+    assert "smartphone laptop" in root_html
 
 
 def test_category_stats_with_centroid(tmp_path):
@@ -601,7 +605,7 @@ def test_category_stats_with_centroid(tmp_path):
     ]
     embeds = {"1-0": [1.0, 0.0]}
     price_utils.prepare_price_fields(lots, {"USD": 1.0}, "USD")
-    cats, stats, _ = build_site._categorise(lots, ["en"], 7, embeds)
+    cats, stats, _ = build_site._categorise(lots, ["en"], 7, embeds, {})
     assert "sell_item.smartphone" in cats
     stat = stats["sell_item.smartphone"]
     assert stat["price_typical"] == 100
@@ -634,7 +638,7 @@ def test_recent_user_count():
         },
     ]
 
-    cats, stats, _ = build_site._categorise(lots, ["en"], 7, {})
+    cats, stats, _ = build_site._categorise(lots, ["en"], 7, {}, {})
     assert "sell_item" in cats
     stat = stats["sell_item"]
     assert stat["recent"] == 1
@@ -656,6 +660,6 @@ def test_phone_sellers_allowed(monkeypatch):
         }
     ]
 
-    cats, stats, _ = build_site._categorise(lots, ["en"], 7, {})
+    cats, stats, _ = build_site._categorise(lots, ["en"], 7, {}, {})
     assert "sell_item" in cats
     assert stats["sell_item"]["users"] == {"+12345"}

--- a/tests/test_cluster_items_import.py
+++ b/tests/test_cluster_items_import.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_import_does_not_install_excepthook(monkeypatch):
+    monkeypatch.setattr(sys, "excepthook", sys.__excepthook__)
+    if "cluster_items" in sys.modules:
+        del sys.modules["cluster_items"]
+    importlib.import_module("cluster_items")
+    assert sys.excepthook is sys.__excepthook__
+


### PR DESCRIPTION
## Summary
- cluster `sell_item` posts into groups using embeddings
- load `data/item_clusters.json` in the site builder
- use cluster info when grouping pages
- document the new `cluster_items.py` service
- test importing the new script
- adjust Makefile for the clustering step

## Testing
- `make precommit` *(fails: `unflatten` not found)*
- `pytest -q` *(fails: `ModuleNotFoundError` for `jinja2` and others)*

------
https://chatgpt.com/codex/tasks/task_e_686040d47a8c83248cf66e86ec3f731d