### PR TITLE
Fix build_site path length

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -209,6 +209,8 @@ generated separately for every language configured in `config.py`.  The
 navigation bar links to the same page in other languages instead of toggling via
 JavaScript. Static files from `templates/static` are copied to
 `data/views/static` so the site works without extra assets.
+Long lot identifiers or category names are truncated with a short hash when
+forming file names so generated paths never exceed OS limits.
 Every page now also includes a currency selector next to the language switcher.
 Prices are converted on the fly in the browser using the rates embedded into
 the page and the last choice is remembered.

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -581,9 +581,13 @@ def test_sell_item_subcategories(tmp_path, monkeypatch, build):
 
     build()
 
-    assert (
-        tmp_path / "views" / "deal" / "sell_item.smartphone laptop_en.html"
-    ).exists()
+    expect = (
+        tmp_path
+        / "views"
+        / "deal"
+        / f"{build_site._slug_component('sell_item.smartphone laptop')}_en.html"
+    )
+    assert expect.exists()
     root_html = (tmp_path / "views" / "deal" / "sell_item_en.html").read_text()
     assert "smartphone laptop" in root_html
 


### PR DESCRIPTION
## Summary
- handle very long identifiers in build_site
- document filename hashing
- update tests

## Testing
- `make precommit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a0f0e0788324bc981201d7f0c85b